### PR TITLE
refactor: Rework iter_errors & validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   lints-rust:
-    name: Rust lints on WASM
+    name: Rust lints
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -175,7 +175,7 @@ jobs:
         working-directory: fuzz
 
   lints-wasm:
-    name: Rust lints
+    name: Rust lints on WASM
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## [Unreleased]
 
+**Important:** This release contains breaking changes. See the [Migration Guide](MIGRATION.md) for details on transitioning to the new API.
+
+### Added
+
+- `Validator::iter_errors` that iterates over all validation errors.
+
 ### Changed
 
 - **BREAKING**: Remove unused `ValidationErrorKind::JSONParse`, `ValidationErrorKind::InvalidReference`, `ValidationErrorKind::Schema`, `ValidationErrorKind::FileNotFound` and `ValidationErrorKind::Utf8`.
+- **BREAKING**: `Validator::validate` now returns the first error instead of an iterator in the `Err` variant. 
 
 ### Performance
 

--- a/Justfile
+++ b/Justfile
@@ -30,5 +30,5 @@ test-py-no-rebuild *FLAGS:
   uvx --with="crates/jsonschema-py[tests]" pytest crates/jsonschema-py/tests-py -rs {{FLAGS}}
 
 bench-py *FLAGS:
-  uvx --with="crates/jsonschema-py[bench]" pytest crates/jsonschema-py/benches/bench.py --benchmark-columns=min {{FLAGS}}
+  uvx --with="crates/jsonschema-py[bench]" --refresh pytest crates/jsonschema-py/benches/bench.py --benchmark-columns=min {{FLAGS}}
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,36 @@
 # Migration Guide
 
+## Upgrading from 0.25.x to 0.26.0
+
+The `Validator::validate` method now returns `Result<(), ValidationError<'i>>` instead of an error iterator. If you need to iterate over all validation errors, use the new `Validator::iter_errors` method.
+
+Example:
+
+```rust
+// Old (0.25.x)
+let validator = jsonschema::validator_for(&schema)?;
+
+if let Err(errors) = validator.validate(&instance) {
+    for error in errors {
+        println!("Error: {error}");
+    }
+}
+
+// New (0.26.0)
+let validator = jsonschema::validator_for(&schema)?;
+
+// To get the first error only
+match validator.validate(&instance) {
+    Ok(()) => println!("Valid!"),
+    Err(error) => println!("Error: {error}"),
+}
+
+// To iterate over all errors
+for error in validator.iter_errors(&instance) {
+    println!("Error: {error}");
+}
+```
+
 ## Upgrading from 0.22.x to 0.23.0
 
 Replace:

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // One-off validation
     assert!(jsonschema::is_valid(&schema, &instance));
+    assert!(jsonschema::validate(&schema, &instance));
 
     // Build & reuse (faster)
     let validator = jsonschema::validator_for(&schema)?;
 
+    // Fail on first error
+    assert!(validator.validate(&instance));
+
     // Iterate over errors
-    if let Err(errors) = validator.validate(&instance) {
-        for error in errors {
-            eprintln!("Error: {}", error);
-            eprintln!("Location: {}", error.instance_path);
-        }
+    for error in validator.iter_errors(&instance) {
+        eprintln!("Error: {error}");
+        eprintln!("Location: {}", error.instance_path);
     }
 
     // Boolean result

--- a/crates/benchmark-suite/benches/jsonschema.rs
+++ b/crates/benchmark-suite/benches/jsonschema.rs
@@ -28,7 +28,7 @@ fn bench_validate(c: &mut Criterion, name: &str, schema: &Value, instance: &Valu
         instance,
         |b, instance| {
             b.iter(|| {
-                let _ = validator.validate(instance);
+                let _ = validator.iter_errors(instance);
             })
         },
     );

--- a/crates/jsonschema-cli/src/main.rs
+++ b/crates/jsonschema-cli/src/main.rs
@@ -43,17 +43,16 @@ fn validate_instances(
         Ok(validator) => {
             for instance in instances {
                 let instance_json = read_json(instance)??;
-                let validation = validator.validate(&instance_json);
+                let errors = validator.iter_errors(&instance_json).collect::<Vec<_>>();
                 let filename = instance.to_string_lossy();
-                match validation {
-                    Ok(()) => println!("{filename} - VALID"),
-                    Err(errors) => {
-                        success = false;
+                if errors.is_empty() {
+                    println!("{filename} - VALID");
+                } else {
+                    success = false;
 
-                        println!("{filename} - INVALID. Errors:");
-                        for (i, e) in errors.enumerate() {
-                            println!("{}. {}", i + 1, e);
-                        }
+                    println!("{filename} - INVALID. Errors:");
+                    for (i, e) in errors.iter().enumerate() {
+                        println!("{}. {}", i + 1, e);
                     }
                 }
             }

--- a/crates/jsonschema/benches/errors.rs
+++ b/crates/jsonschema/benches/errors.rs
@@ -4,11 +4,7 @@ use serde_json::Value;
 
 fn bench_error_formatting(c: &mut Criterion, name: &str, schema: &Value, instance: &Value) {
     let validator = jsonschema::validator_for(schema).expect("Valid schema");
-    let error = validator
-        .validate(instance)
-        .unwrap_err()
-        .next()
-        .expect("Should have at least one error");
+    let error = validator.validate(instance).unwrap_err();
 
     c.bench_with_input(
         BenchmarkId::new("error_formatting", name),

--- a/crates/jsonschema/src/compiler.rs
+++ b/crates/jsonschema/src/compiler.rs
@@ -321,16 +321,12 @@ pub(crate) fn build_validator(
 
     // Validate the schema itself
     if config.validate_schema {
-        if let Some(mut errors) = META_SCHEMA_VALIDATORS
+        if let Err(error) = META_SCHEMA_VALIDATORS
             .get(&draft)
             .expect("Existing draft")
             .validate(schema)
-            .err()
         {
-            return Err(errors
-                .next()
-                .expect("Should have at least one element")
-                .into_owned());
+            return Err(error.into_owned());
         }
     }
 

--- a/crates/jsonschema/src/error.rs
+++ b/crates/jsonschema/src/error.rs
@@ -36,11 +36,9 @@ pub struct ValidationError<'a> {
 /// let schema = json!({"maxLength": 5});
 /// let instance = json!("foo");
 /// if let Ok(validator) = jsonschema::validator_for(&schema) {
-///     let result = validator.validate(&instance);
-///     if let Err(errors) = result {
-///         for error in errors {
-///             println!("Validation error: {}", error)
-///         }
+///     let errors = validator.iter_errors(&instance);
+///     for error in errors {
+///         println!("Validation error: {}", error)
 ///     }
 /// }
 /// ```
@@ -998,7 +996,7 @@ mod tests {
             }
         );
         let validator = crate::validator_for(&schema).unwrap();
-        let mut result = validator.validate(instance).expect_err("error iterator");
+        let mut result = validator.iter_errors(instance);
         let error = result.next().expect("validation error");
 
         assert!(result.next().is_none());
@@ -1039,7 +1037,7 @@ mod tests {
             }
         );
         let validator = crate::validator_for(&schema).unwrap();
-        let mut result = validator.validate(instance).expect_err("error iterator");
+        let mut result = validator.iter_errors(instance);
         let error = result.next().expect("validation error");
 
         assert!(result.next().is_none());
@@ -1064,7 +1062,7 @@ mod tests {
             }
         );
         let validator = crate::validator_for(&schema).unwrap();
-        let mut result = validator.validate(instance).expect_err("error iterator");
+        let mut result = validator.iter_errors(instance);
         let error = result.next().expect("validation error");
 
         assert!(result.next().is_none());
@@ -1086,7 +1084,7 @@ mod tests {
             }
         );
         let validator = crate::validator_for(&schema).unwrap();
-        let mut result = validator.validate(instance).expect_err("error iterator");
+        let mut result = validator.iter_errors(instance);
         let error = result.next().expect("validation error");
 
         assert!(result.next().is_none());

--- a/crates/jsonschema/src/keywords/any_of.rs
+++ b/crates/jsonschema/src/keywords/any_of.rs
@@ -42,15 +42,31 @@ impl AnyOfValidator {
 }
 
 impl Validate for AnyOfValidator {
-    fn is_valid(&self, instance: &Value) -> bool {
-        self.schemas.iter().any(|s| s.is_valid(instance))
-    }
-
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn iter_errors<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
         if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::any_of(
+                self.location.clone(),
+                location.into(),
+                instance,
+            ))
+        }
+    }
+
+    fn is_valid(&self, instance: &Value) -> bool {
+        self.schemas.iter().any(|s| s.is_valid(instance))
+    }
+
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
+        if self.is_valid(instance) {
+            Ok(())
+        } else {
+            Err(ValidationError::any_of(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/boolean.rs
+++ b/crates/jsonschema/src/keywords/boolean.rs
@@ -1,10 +1,6 @@
 use crate::paths::{LazyLocation, Location};
 
-use crate::{
-    error::{error, ErrorIterator, ValidationError},
-    keywords::CompilationResult,
-    validator::Validate,
-};
+use crate::{error::ValidationError, keywords::CompilationResult, validator::Validate};
 use serde_json::Value;
 
 pub(crate) struct FalseValidator {
@@ -21,8 +17,12 @@ impl Validate for FalseValidator {
         false
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
-        error(ValidationError::false_schema(
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
+        Err(ValidationError::false_schema(
             self.location.clone(),
             location.into(),
             instance,

--- a/crates/jsonschema/src/keywords/const_.rs
+++ b/crates/jsonschema/src/keywords/const_.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers, CompilationResult},
     paths::Location,
     validator::Validate,
@@ -23,12 +23,15 @@ impl ConstArrayValidator {
     }
 }
 impl Validate for ConstArrayValidator {
-    #[inline]
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::constant_array(
+            Err(ValidationError::constant_array(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -58,12 +61,15 @@ impl ConstBooleanValidator {
     }
 }
 impl Validate for ConstBooleanValidator {
-    #[inline]
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::constant_boolean(
+            Err(ValidationError::constant_boolean(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -92,19 +98,21 @@ impl ConstNullValidator {
     }
 }
 impl Validate for ConstNullValidator {
-    #[inline]
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::constant_null(
+            Err(ValidationError::constant_null(
                 self.location.clone(),
                 location.into(),
                 instance,
             ))
         }
     }
-
     #[inline]
     fn is_valid(&self, instance: &Value) -> bool {
         instance.is_null()
@@ -132,11 +140,15 @@ impl ConstNumberValidator {
 }
 
 impl Validate for ConstNumberValidator {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::constant_number(
+            Err(ValidationError::constant_number(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -170,11 +182,15 @@ impl ConstObjectValidator {
 }
 
 impl Validate for ConstObjectValidator {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::constant_object(
+            Err(ValidationError::constant_object(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -182,7 +198,6 @@ impl Validate for ConstObjectValidator {
             ))
         }
     }
-
     fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             helpers::equal_objects(&self.value, item)
@@ -208,11 +223,15 @@ impl ConstStringValidator {
 }
 
 impl Validate for ConstStringValidator {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::constant_string(
+            Err(ValidationError::constant_string(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -220,7 +239,6 @@ impl Validate for ConstStringValidator {
             ))
         }
     }
-
     fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             &self.value == item

--- a/crates/jsonschema/src/keywords/custom.rs
+++ b/crates/jsonschema/src/keywords/custom.rs
@@ -1,7 +1,7 @@
 use crate::{
     paths::{LazyLocation, Location},
     validator::Validate,
-    ErrorIterator, ValidationError,
+    ValidationError,
 };
 use serde_json::{Map, Value};
 
@@ -16,7 +16,11 @@ impl CustomKeyword {
 }
 
 impl Validate for CustomKeyword {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         self.inner.validate(instance, location)
     }
 
@@ -33,7 +37,11 @@ pub trait Keyword: Send + Sync {
     /// easily or efficiently expressed in JSON schema.
     ///
     /// The custom validation is applied in addition to the JSON schema validation.
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i>;
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>>;
     /// Validate instance and return a boolean result.
     ///
     /// Could be potentilly faster than [`Keyword::validate`] method.

--- a/crates/jsonschema/src/keywords/dependencies.rs
+++ b/crates/jsonschema/src/keywords/dependencies.rs
@@ -60,19 +60,34 @@ impl Validate for DependenciesValidator {
     }
 
     #[allow(clippy::needless_collect)]
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn iter_errors<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
         if let Value::Object(item) = instance {
             let errors: Vec<_> = self
                 .dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .flat_map(move |(_, node)| node.validate(instance, location))
+                .flat_map(move |(_, node)| node.iter_errors(instance, location))
                 .collect();
             // TODO. custom error message for "required" case
             Box::new(errors.into_iter())
         } else {
             no_error()
         }
+    }
+
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
+        if let Value::Object(item) = instance {
+            for (property, dependency) in &self.dependencies {
+                if item.contains_key(property) {
+                    dependency.validate(instance, location)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -125,6 +140,19 @@ impl DependentRequiredValidator {
     }
 }
 impl Validate for DependentRequiredValidator {
+    fn iter_errors<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+        if let Value::Object(item) = instance {
+            let errors: Vec<_> = self
+                .dependencies
+                .iter()
+                .filter(|(property, _)| item.contains_key(property))
+                .flat_map(move |(_, node)| node.iter_errors(instance, location))
+                .collect();
+            Box::new(errors.into_iter())
+        } else {
+            no_error()
+        }
+    }
     fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             self.dependencies
@@ -135,17 +163,21 @@ impl Validate for DependentRequiredValidator {
             true
         }
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::Object(item) = instance {
-            let errors: Vec<_> = self
-                .dependencies
-                .iter()
-                .filter(|(property, _)| item.contains_key(property))
-                .flat_map(move |(_, node)| node.validate(instance, location))
-                .collect();
-            Box::new(errors.into_iter())
+            for (property, dependency) in &self.dependencies {
+                if item.contains_key(property) {
+                    dependency.validate(instance, location)?;
+                }
+            }
+            Ok(())
         } else {
-            no_error()
+            Ok(())
         }
     }
 }
@@ -176,6 +208,19 @@ impl DependentSchemasValidator {
     }
 }
 impl Validate for DependentSchemasValidator {
+    fn iter_errors<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+        if let Value::Object(item) = instance {
+            let errors: Vec<_> = self
+                .dependencies
+                .iter()
+                .filter(|(property, _)| item.contains_key(property))
+                .flat_map(move |(_, node)| node.iter_errors(instance, location))
+                .collect();
+            Box::new(errors.into_iter())
+        } else {
+            no_error()
+        }
+    }
     fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             self.dependencies
@@ -186,17 +231,21 @@ impl Validate for DependentSchemasValidator {
             true
         }
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::Object(item) = instance {
-            let errors: Vec<_> = self
-                .dependencies
-                .iter()
-                .filter(|(property, _)| item.contains_key(property))
-                .flat_map(move |(_, node)| node.validate(instance, location))
-                .collect();
-            Box::new(errors.into_iter())
+            for (property, dependency) in &self.dependencies {
+                if item.contains_key(property) {
+                    dependency.validate(instance, location)?;
+                }
+            }
+            Ok(())
         } else {
-            no_error()
+            Ok(())
         }
     }
 }

--- a/crates/jsonschema/src/keywords/enum_.rs
+++ b/crates/jsonschema/src/keywords/enum_.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers, CompilationResult},
     paths::{LazyLocation, Location},
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
@@ -38,11 +38,15 @@ impl EnumValidator {
 }
 
 impl Validate for EnumValidator {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::enumeration(
+            Err(ValidationError::enumeration(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -86,11 +90,15 @@ impl SingleValueEnumValidator {
 }
 
 impl Validate for SingleValueEnumValidator {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::enumeration(
+            Err(ValidationError::enumeration(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/exclusive_maximum.rs
+++ b/crates/jsonschema/src/keywords/exclusive_maximum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::{LazyLocation, Location},
     primitive_type::PrimitiveType,
@@ -32,11 +32,11 @@ macro_rules! validate {
                 &self,
                 instance: &'i Value,
                 location: &LazyLocation,
-            ) -> ErrorIterator<'i> {
+            ) -> Result<(), ValidationError<'i>> {
                 if self.is_valid(instance) {
-                    no_error()
+                    Ok(())
                 } else {
-                    error(ValidationError::exclusive_maximum(
+                    Err(ValidationError::exclusive_maximum(
                         self.location.clone(),
                         location.into(),
                         instance,
@@ -82,11 +82,15 @@ impl Validate for ExclusiveMaximumF64Validator {
         }
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::exclusive_maximum(
+            Err(ValidationError::exclusive_maximum(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/exclusive_minimum.rs
+++ b/crates/jsonschema/src/keywords/exclusive_minimum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::{LazyLocation, Location},
     primitive_type::PrimitiveType,
@@ -32,11 +32,11 @@ macro_rules! validate {
                 &self,
                 instance: &'i Value,
                 location: &LazyLocation,
-            ) -> ErrorIterator<'i> {
+            ) -> Result<(), ValidationError<'i>> {
                 if self.is_valid(instance) {
-                    no_error()
+                    Ok(())
                 } else {
-                    error(ValidationError::exclusive_minimum(
+                    Err(ValidationError::exclusive_minimum(
                         self.location.clone(),
                         location.into(),
                         instance,
@@ -80,11 +80,15 @@ impl Validate for ExclusiveMinimumF64Validator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::exclusive_minimum(
+            Err(ValidationError::exclusive_minimum(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/legacy/type_draft_4.rs
+++ b/crates/jsonschema/src/keywords/legacy/type_draft_4.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{type_, CompilationResult},
     paths::{LazyLocation, Location},
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
@@ -62,11 +62,15 @@ impl Validate for MultipleTypesValidator {
             Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::multiple_type_error(
+            Err(ValidationError::multiple_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -95,12 +99,15 @@ impl Validate for IntegerTypeValidator {
             false
         }
     }
-
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/max_items.rs
+++ b/crates/jsonschema/src/keywords/max_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{LazyLocation, Location},
     validator::Validate,
@@ -48,10 +48,14 @@ impl Validate for MaxItemsValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::Array(items) = instance {
             if (items.len() as u64) > self.limit {
-                return error(ValidationError::max_items(
+                return Err(ValidationError::max_items(
                     self.location.clone(),
                     location.into(),
                     instance,
@@ -59,7 +63,7 @@ impl Validate for MaxItemsValidator {
                 ));
             }
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/max_length.rs
+++ b/crates/jsonschema/src/keywords/max_length.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{LazyLocation, Location},
     validator::Validate,
@@ -48,10 +48,14 @@ impl Validate for MaxLengthValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::String(item) = instance {
             if (bytecount::num_chars(item.as_bytes()) as u64) > self.limit {
-                return error(ValidationError::max_length(
+                return Err(ValidationError::max_length(
                     self.location.clone(),
                     location.into(),
                     instance,
@@ -59,7 +63,7 @@ impl Validate for MaxLengthValidator {
                 ));
             }
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/max_properties.rs
+++ b/crates/jsonschema/src/keywords/max_properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{LazyLocation, Location},
     validator::Validate,
@@ -48,10 +48,14 @@ impl Validate for MaxPropertiesValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::Object(item) = instance {
             if (item.len() as u64) > self.limit {
-                return error(ValidationError::max_properties(
+                return Err(ValidationError::max_properties(
                     self.location.clone(),
                     location.into(),
                     instance,
@@ -59,7 +63,7 @@ impl Validate for MaxPropertiesValidator {
                 ));
             }
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/maximum.rs
+++ b/crates/jsonschema/src/keywords/maximum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::{LazyLocation, Location},
     primitive_type::PrimitiveType,
@@ -32,11 +32,11 @@ macro_rules! validate {
                 &self,
                 instance: &'i Value,
                 location: &LazyLocation,
-            ) -> ErrorIterator<'i> {
+            ) -> Result<(), ValidationError<'i>> {
                 if self.is_valid(instance) {
-                    no_error()
+                    Ok(())
                 } else {
-                    error(ValidationError::maximum(
+                    Err(ValidationError::maximum(
                         self.location.clone(),
                         location.into(),
                         instance,
@@ -80,11 +80,15 @@ impl Validate for MaximumF64Validator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::maximum(
+            Err(ValidationError::maximum(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/min_items.rs
+++ b/crates/jsonschema/src/keywords/min_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{LazyLocation, Location},
     validator::Validate,
@@ -48,10 +48,14 @@ impl Validate for MinItemsValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::Array(items) = instance {
             if (items.len() as u64) < self.limit {
-                return error(ValidationError::min_items(
+                return Err(ValidationError::min_items(
                     self.location.clone(),
                     location.into(),
                     instance,
@@ -59,7 +63,7 @@ impl Validate for MinItemsValidator {
                 ));
             }
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/min_length.rs
+++ b/crates/jsonschema/src/keywords/min_length.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{LazyLocation, Location},
     validator::Validate,
@@ -48,10 +48,14 @@ impl Validate for MinLengthValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::String(item) = instance {
             if (bytecount::num_chars(item.as_bytes()) as u64) < self.limit {
-                return error(ValidationError::min_length(
+                return Err(ValidationError::min_length(
                     self.location.clone(),
                     location.into(),
                     instance,
@@ -59,7 +63,7 @@ impl Validate for MinLengthValidator {
                 ));
             }
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/min_properties.rs
+++ b/crates/jsonschema/src/keywords/min_properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{LazyLocation, Location},
     validator::Validate,
@@ -48,10 +48,14 @@ impl Validate for MinPropertiesValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::Object(item) = instance {
             if (item.len() as u64) < self.limit {
-                return error(ValidationError::min_properties(
+                return Err(ValidationError::min_properties(
                     self.location.clone(),
                     location.into(),
                     instance,
@@ -59,7 +63,7 @@ impl Validate for MinPropertiesValidator {
                 ));
             }
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/minimum.rs
+++ b/crates/jsonschema/src/keywords/minimum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::{LazyLocation, Location},
     primitive_type::PrimitiveType,
@@ -32,11 +32,11 @@ macro_rules! validate {
                 &self,
                 instance: &'i Value,
                 location: &LazyLocation,
-            ) -> ErrorIterator<'i> {
+            ) -> Result<(), ValidationError<'i>> {
                 if self.is_valid(instance) {
-                    no_error()
+                    Ok(())
                 } else {
-                    error(ValidationError::minimum(
+                    Err(ValidationError::minimum(
                         self.location.clone(),
                         location.into(),
                         instance,
@@ -80,11 +80,15 @@ impl Validate for MinimumF64Validator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::minimum(
+            Err(ValidationError::minimum(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/mod.rs
+++ b/crates/jsonschema/src/keywords/mod.rs
@@ -434,13 +434,7 @@ mod tests {
             .should_validate_formats(true)
             .build(schema)
             .expect("Invalid schema");
-        let errors: Vec<_> = validator
-            .validate(instance)
-            .expect_err(&format!(
-                "Validation error is expected. Schema=`{:?}` Instance=`{:?}`",
-                schema, instance
-            ))
-            .collect();
+        let errors: Vec<_> = validator.iter_errors(instance).collect();
         assert_eq!(errors[0].to_string(), expected);
     }
 
@@ -524,10 +518,7 @@ mod tests {
         let schema = json!({"required": ["foo", "bar"]});
         let instance = json!({});
         let validator = crate::validator_for(&schema).unwrap();
-        let errors: Vec<_> = validator
-            .validate(&instance)
-            .expect_err("Validation errors")
-            .collect();
+        let errors: Vec<_> = validator.iter_errors(&instance).collect();
         assert_eq!(errors.len(), 2);
         assert_eq!(errors[0].to_string(), r#""foo" is a required property"#);
         assert_eq!(errors[1].to_string(), r#""bar" is a required property"#);

--- a/crates/jsonschema/src/keywords/multiple_of.rs
+++ b/crates/jsonschema/src/keywords/multiple_of.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::{LazyLocation, Location},
     primitive_type::PrimitiveType,
@@ -45,16 +45,20 @@ impl Validate for MultipleOfFloatValidator {
         }
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if !self.is_valid(instance) {
-            return error(ValidationError::multiple_of(
+            return Err(ValidationError::multiple_of(
                 self.location.clone(),
                 location.into(),
                 instance,
                 self.multiple_of,
             ));
         }
-        no_error()
+        Ok(())
     }
 }
 
@@ -85,16 +89,20 @@ impl Validate for MultipleOfIntegerValidator {
         }
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if !self.is_valid(instance) {
-            return error(ValidationError::multiple_of(
+            return Err(ValidationError::multiple_of(
                 self.location.clone(),
                 location.into(),
                 instance,
                 self.multiple_of,
             ));
         }
-        no_error()
+        Ok(())
     }
 }
 

--- a/crates/jsonschema/src/keywords/not.rs
+++ b/crates/jsonschema/src/keywords/not.rs
@@ -1,10 +1,6 @@
 use crate::{
-    compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
-    keywords::CompilationResult,
-    node::SchemaNode,
-    paths::LazyLocation,
-    validator::Validate,
+    compiler, error::ValidationError, keywords::CompilationResult, node::SchemaNode,
+    paths::LazyLocation, validator::Validate,
 };
 use serde_json::{Map, Value};
 
@@ -30,11 +26,15 @@ impl Validate for NotValidator {
         !self.node.is_valid(instance)
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::not(
+            Err(ValidationError::not(
                 self.node.location().clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/one_of.rs
+++ b/crates/jsonschema/src/keywords/one_of.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     node::SchemaNode,
     output::BasicOutput,
@@ -68,19 +68,23 @@ impl Validate for OneOfValidator {
         let first_valid_idx = self.get_first_valid(instance);
         first_valid_idx.map_or(false, |idx| !self.are_others_valid(instance, idx))
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         let first_valid_idx = self.get_first_valid(instance);
         if let Some(idx) = first_valid_idx {
             if self.are_others_valid(instance, idx) {
-                return error(ValidationError::one_of_multiple_valid(
+                return Err(ValidationError::one_of_multiple_valid(
                     self.location.clone(),
                     location.into(),
                     instance,
                 ));
             }
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::one_of_not_valid(
+            Err(ValidationError::one_of_not_valid(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/pattern.rs
+++ b/crates/jsonschema/src/keywords/pattern.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler, ecma,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::{LazyLocation, Location},
     primitive_type::PrimitiveType,
@@ -108,12 +108,16 @@ impl PatternValidator {
 }
 
 impl Validate for PatternValidator {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if let Value::String(item) = instance {
             match self.pattern.is_match(item) {
                 Ok(is_match) => {
                     if !is_match {
-                        return error(ValidationError::pattern(
+                        return Err(ValidationError::pattern(
                             self.location.clone(),
                             location.into(),
                             instance,
@@ -122,7 +126,7 @@ impl Validate for PatternValidator {
                     }
                 }
                 Err(e) => {
-                    return error(ValidationError::backtrack_limit(
+                    return Err(ValidationError::backtrack_limit(
                         self.location.clone(),
                         location.into(),
                         instance,
@@ -131,7 +135,7 @@ impl Validate for PatternValidator {
                 }
             }
         }
-        no_error()
+        Ok(())
     }
 
     fn is_valid(&self, instance: &Value) -> bool {

--- a/crates/jsonschema/src/keywords/type_.rs
+++ b/crates/jsonschema/src/keywords/type_.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     paths::Location,
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
@@ -64,11 +64,15 @@ impl Validate for MultipleTypesValidator {
             Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::multiple_type_error(
+            Err(ValidationError::multiple_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -93,11 +97,15 @@ impl Validate for NullTypeValidator {
     fn is_valid(&self, instance: &Value) -> bool {
         instance.is_null()
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -122,11 +130,15 @@ impl Validate for BooleanTypeValidator {
     fn is_valid(&self, instance: &Value) -> bool {
         instance.is_boolean()
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -152,11 +164,15 @@ impl Validate for StringTypeValidator {
         instance.is_string()
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -182,11 +198,15 @@ impl Validate for ArrayTypeValidator {
         instance.is_array()
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -211,11 +231,15 @@ impl Validate for ObjectTypeValidator {
     fn is_valid(&self, instance: &Value) -> bool {
         instance.is_object()
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -240,11 +264,15 @@ impl Validate for NumberTypeValidator {
     fn is_valid(&self, instance: &Value) -> bool {
         instance.is_number()
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,
@@ -273,11 +301,15 @@ impl Validate for IntegerTypeValidator {
             false
         }
     }
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::single_type_error(
+            Err(ValidationError::single_type_error(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/keywords/unique_items.rs
+++ b/crates/jsonschema/src/keywords/unique_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compiler,
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{helpers::equal, CompilationResult},
     paths::Location,
     validator::Validate,
@@ -117,11 +117,15 @@ impl Validate for UniqueItemsValidator {
         true
     }
 
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>> {
         if self.is_valid(instance) {
-            no_error()
+            Ok(())
         } else {
-            error(ValidationError::unique_items(
+            Err(ValidationError::unique_items(
                 self.location.clone(),
                 location.into(),
                 instance,

--- a/crates/jsonschema/src/options.rs
+++ b/crates/jsonschema/src/options.rs
@@ -395,18 +395,17 @@ impl ValidationOptions {
     ///         &self,
     ///         instance: &'i Value,
     ///         location: &LazyLocation,
-    ///     ) -> ErrorIterator<'i> {
+    ///     ) -> Result<(), ValidationError<'i>> {
     ///         // ... validate instance ...
     ///         if !instance.is_object() {
-    ///             let error = ValidationError::custom(
+    ///             return Err(ValidationError::custom(
     ///                 Location::new(),
     ///                 location.into(),
     ///                 instance,
     ///                 "Boom!",
-    ///             );
-    ///             Box::new(once(error))
+    ///             ));
     ///         } else {
-    ///             Box::new(None.into_iter())
+    ///             Ok(())
     ///         }
     ///     }
     ///     fn is_valid(&self, instance: &Value) -> bool {

--- a/crates/jsonschema/src/validator.rs
+++ b/crates/jsonschema/src/validator.rs
@@ -2,7 +2,7 @@
 //! The main idea is to create a tree from the input JSON Schema. This tree will contain
 //! everything needed to perform such validation in runtime.
 use crate::{
-    error::ErrorIterator,
+    error::{error, no_error, ErrorIterator},
     node::SchemaNode,
     output::{Annotations, ErrorDescription, Output, OutputUnit},
     paths::LazyLocation,
@@ -26,11 +26,22 @@ use std::{collections::VecDeque, sync::Arc};
 /// `is_valid`. `apply` is only necessary for validators which compose other validators. See the
 /// documentation for `apply` for more information.
 pub(crate) trait Validate: Send + Sync {
-    fn validate<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i>;
+    fn iter_errors<'i>(&self, instance: &'i Value, location: &LazyLocation) -> ErrorIterator<'i> {
+        match self.validate(instance, location) {
+            Ok(()) => no_error(),
+            Err(err) => error(err),
+        }
+    }
     // The same as above, but does not construct ErrorIterator.
     // It is faster for cases when the result is not needed (like anyOf), since errors are
     // not constructed
     fn is_valid(&self, instance: &Value) -> bool;
+
+    fn validate<'i>(
+        &self,
+        instance: &'i Value,
+        location: &LazyLocation,
+    ) -> Result<(), ValidationError<'i>>;
 
     /// `apply` applies this validator and any sub-validators it is composed of to the value in
     /// question and collects the resulting annotations or errors. Note that the result of `apply`
@@ -77,7 +88,7 @@ pub(crate) trait Validate: Send + Sync {
     /// so you can use `sum()` and `collect()` in simple cases.
     fn apply<'a>(&'a self, instance: &Value, location: &LazyLocation) -> PartialApplication<'a> {
         let errors: Vec<ErrorDescription> = self
-            .validate(instance, location)
+            .iter_errors(instance, location)
             .map(ErrorDescription::from)
             .collect();
         if errors.is_empty() {
@@ -184,14 +195,13 @@ impl Validator {
     }
     /// Run validation against `instance` and return an iterator over [`ValidationError`] in the error case.
     #[inline]
-    pub fn validate<'i>(&'i self, instance: &'i Value) -> Result<(), ErrorIterator<'i>> {
-        let instance_path = LazyLocation::new();
-        let mut errors = self.root.validate(instance, &instance_path).peekable();
-        if errors.peek().is_none() {
-            Ok(())
-        } else {
-            Err(Box::new(errors))
-        }
+    pub fn validate<'i>(&self, instance: &'i Value) -> Result<(), ValidationError<'i>> {
+        self.root.validate(instance, &LazyLocation::new())
+    }
+    /// Run validation against `instance` and return an iterator over [`ValidationError`] in the error case.
+    #[inline]
+    pub fn iter_errors<'i>(&'i self, instance: &'i Value) -> ErrorIterator<'i> {
+        self.root.iter_errors(instance, &LazyLocation::new())
     }
     /// Run validation against `instance` but return a boolean result instead of an iterator.
     /// It is useful for cases, where it is important to only know the fact if the data is valid or not.
@@ -262,11 +272,11 @@ impl Validator {
 #[cfg(test)]
 mod tests {
     use crate::{
-        error::{self, no_error, ValidationError},
+        error::ValidationError,
         keywords::custom::Keyword,
         paths::{LazyLocation, Location},
         primitive_type::PrimitiveType,
-        ErrorIterator, Validator,
+        Validator,
     };
     use fancy_regex::Regex;
     use num_cmp::NumCmp;
@@ -321,8 +331,7 @@ mod tests {
         let schema = json!({"minProperties": 2, "propertyNames": {"minLength": 3}});
         let value = json!({"a": 3});
         let validator = crate::validator_for(&schema).unwrap();
-        let result = validator.validate(&value);
-        let errors: Vec<ValidationError> = result.unwrap_err().collect();
+        let errors: Vec<_> = validator.iter_errors(&value).collect();
         assert_eq!(errors.len(), 2);
         assert_eq!(
             errors[0].to_string(),
@@ -343,20 +352,18 @@ mod tests {
                 &self,
                 instance: &'i Value,
                 location: &LazyLocation,
-            ) -> ErrorIterator<'i> {
-                let mut errors = vec![];
+            ) -> Result<(), ValidationError<'i>> {
                 for key in instance.as_object().unwrap().keys() {
                     if !key.is_ascii() {
-                        let error = ValidationError::custom(
+                        return Err(ValidationError::custom(
                             Location::new(),
                             location.into(),
                             instance,
                             "Key is not ASCII",
-                        );
-                        errors.push(error);
+                        ));
                     }
                 }
-                Box::new(errors.into_iter())
+                Ok(())
             }
 
             fn is_valid(&self, instance: &Value) -> bool {
@@ -407,11 +414,7 @@ mod tests {
 
         // Verify validator detects invalid custom-object-type
         let instance = json!({ "å" : 1 });
-        let error = validator
-            .validate(&instance)
-            .expect_err("Should fail")
-            .next()
-            .expect("Not empty");
+        let error = validator.validate(&instance).expect_err("Should fail");
         assert_eq!(error.to_string(), "Key is not ASCII");
         assert!(!validator.is_valid(&instance));
     }
@@ -439,11 +442,11 @@ mod tests {
                 &self,
                 instance: &'i Value,
                 location: &LazyLocation,
-            ) -> ErrorIterator<'i> {
+            ) -> Result<(), ValidationError<'i>> {
                 if self.is_valid(instance) {
-                    no_error()
+                    Ok(())
                 } else {
-                    error::error(ValidationError::minimum(
+                    Err(ValidationError::minimum(
                         self.location.clone(),
                         location.into(),
                         instance,

--- a/fuzz/fuzz_targets/validation.rs
+++ b/fuzz/fuzz_targets/validation.rs
@@ -7,10 +7,9 @@ fuzz_target!(|data: (&[u8], &[u8])| {
         if let Ok(validator) = jsonschema::validator_for(&schema) {
             if let Ok(instance) = serde_json::from_slice(instance) {
                 let _ = validator.is_valid(&instance);
-                if let Err(errors) = validator.validate(&instance) {
-                    for error in errors {
-                        let _ = error.to_string();
-                    }
+                let _ = validator.validate(&instance);
+                for error in validator.iter_errors(&instance) {
+                    let _ = error.to_string();
                 }
                 let output = validator.apply(&instance).basic();
                 let _ = serde_json::to_value(output).expect("Failed to serialize");

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -40,14 +40,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let _ = validator.is_valid(&instance);
             }
             "validate" => {
-                if let Err(errors) = validator.validate(&instance) {
-                    for _error in errors {}
-                }
+                let _ = validator.validate(&instance);
             }
+            "iter_errors" => for _error in validator.iter_errors(&instance) {},
             "apply" => {
                 let _ = validator.apply(&instance).basic();
             }
-            _ => panic!("Invalid method. Use 'build', 'is_valid', 'validate', or 'apply'"),
+            _ => panic!(
+                "Invalid method. Use 'build', 'is_valid', 'validate', 'iter_errors`, or 'apply'"
+            ),
         }
     }
 


### PR DESCRIPTION
This PR introduces a few important breaking changes to the public API:

- Change the return type of the `Validator::validate` to `Result<(), ValidationError<'i>>`
- Add `Validator::iter_errors` that returns `ErrorIterator<'i>`

Which is essentially a split of the existing `Validator::validate` methods into two methods, one of which returns the first error, and the second one allows iterating over all errors.

Besides the performance improvements for cases when the user needs just the first error (Python bindings benefit a lot from it), it is also a step toward a clearer API. 

I see the new API as less surprising because:
- with the new `validate` methods, the user won't have to check the first value of the iterator to get the error - it is there straight away. 
- If the user needs all errors, then iteration does not involve unwrapping `Result`, which I think is desirable

Another pending change is to implement #451, but I am not 100% about the error formatting inside the iterator `Display`

TODO:
- [x] Migration guide
- [x] Documentation
- [x] Top-level `jsonschema::validate` function.