### PR TITLE
perf: short-circuit SchemaNode.is_valid

### DIFF
--- a/crates/jsonschema/src/node.rs
+++ b/crates/jsonschema/src/node.rs
@@ -334,7 +334,12 @@ impl Validate for SchemaNode {
                 kvs.validators[0].1.is_valid(instance)
             }
             NodeValidators::Keyword(kvs) => {
-                kvs.validators.iter().all(|(_, v)| v.is_valid(instance))
+                for (_, v) in &kvs.validators {
+                    if !v.is_valid(instance) {
+                        return false;
+                    }
+                }
+                true
             }
             NodeValidators::Array { validators } => validators.iter().all(|v| v.is_valid(instance)),
             NodeValidators::Boolean { validator: Some(_) } => false,


### PR DESCRIPTION
there's an optimization already for just one validator, perhaps, we should short-circuit as well as soon as one validator is not valid