### PR TITLE
fix: Return "Unknown specification" error on `https`-prefixed `$schema` for Draft 4, 5, 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Return "Unknown specification" error on `https`-prefixed `$schema` for Draft 4, 5, 6. [#629](https://github.com/Stranger6667/jsonschema/issues/629)
+
 ## [0.26.0] - 2024-10-26
 
 **Important:** This release contains breaking changes. See the [Migration Guide](MIGRATION.md) for details on transitioning to the new API.

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Return "Unknown specification" error on `https`-prefixed `$schema` for Draft 4, 5, 6. [#629](https://github.com/Stranger6667/jsonschema/issues/629)
+
 ### Performance
 
 - Speedup Python -> Rust data serialization.

--- a/crates/jsonschema-py/tests-py/test_jsonschema.py
+++ b/crates/jsonschema-py/tests-py/test_jsonschema.py
@@ -155,6 +155,13 @@ def test_invalid_value(method):
         getattr(schema, method)(object())
 
 
+def test_invalid_schema_keyword():
+    # Note `https`, not `http`
+    schema = {"$schema": "https://json-schema.org/draft-07/schema"}
+    with pytest.raises(ValidationError, match="Unknown specification: https://json-schema.org/draft-07/schema"):
+        validator_for(schema)
+
+
 def test_error_message():
     schema = {"properties": {"foo": {"type": "integer"}}}
     instance = {"foo": None}

--- a/crates/jsonschema/src/compiler.rs
+++ b/crates/jsonschema/src/compiler.rs
@@ -285,7 +285,7 @@ pub(crate) fn build_validator(
     mut config: ValidationOptions,
     schema: &Value,
 ) -> Result<Validator, ValidationError<'static>> {
-    let draft = config.draft_for(schema);
+    let draft = config.draft_for(schema)?;
     let resource_ref = draft.create_resource_ref(schema);
     let resource = draft.create_resource(schema.clone());
     let base_uri = resource.id().unwrap_or(DEFAULT_ROOT_URL).to_string();

--- a/crates/jsonschema/src/lib.rs
+++ b/crates/jsonschema/src/lib.rs
@@ -1335,6 +1335,19 @@ mod tests {
         assert!(validate_fn(&schema, &invalid_instance).is_err());
     }
 
+    #[test]
+    fn test_invalid_schema_keyword() {
+        let schema = json!({
+            // Note `https`, not `http`
+            "$schema": "https://json-schema.org/draft-07/schema",
+        });
+        let error = crate::validator_for(&schema).expect_err("Should fail");
+        assert_eq!(
+            error.to_string(),
+            "Unknown specification: https://json-schema.org/draft-07/schema"
+        );
+    }
+
     #[test_case(Draft::Draft4)]
     #[test_case(Draft::Draft6)]
     #[test_case(Draft::Draft7)]


### PR DESCRIPTION
Resolves #629 