### PR TITLE
feat(python): Extend `ValidationErrorKind` with error-specific context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Implement `ExactSizeIterator` for `PrimitiveTypesBitMapIterator`.
+
 ## [0.27.0] - 2024-12-23
 
 ### Added

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Extend `ValidationErrorKind` with error-specific context data.
+- Missing type annotations for `retriever` & `mask` arguments.
+
 ## [0.27.0] - 2024-12-23
 
 ### Added

--- a/crates/jsonschema-py/README.md
+++ b/crates/jsonschema-py/README.md
@@ -197,7 +197,32 @@ validator.is_valid({
 })  # False
 ```
 
-## Error Message Masking
+## Error Handling
+
+`jsonschema-rs` provides detailed validation errors through the `ValidationError` class, which includes both basic error information and specific details about what caused the validation to fail:
+
+```python
+import jsonschema_rs
+
+schema = {"type": "string", "maxLength": 5}
+
+try:
+    jsonschema_rs.validate(schema, "too long")
+except jsonschema_rs.ValidationError as error:
+    # Basic error information
+    print(error.message)       # '"too long" is longer than 5 characters'
+    print(error.instance_path) # Location in the instance that failed
+    print(error.schema_path)   # Location in the schema that failed
+
+    # Detailed error information via `kind`
+    if isinstance(error.kind, jsonschema_rs.ValidationErrorKind.MaxLength):
+        assert error.kind.limit == 5
+        print(f"Exceeded maximum length of {error.kind.limit}")
+```
+
+For a complete list of all error kinds and their attributes, see the [type definitions file](https://github.com/Stranger6667/jsonschema/blob/master/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi)
+
+### Error Message Masking
 
 When working with sensitive data, you might want to hide actual values from error messages.
 You can mask instance values in error messages by providing a placeholder:

--- a/crates/jsonschema/src/primitive_type.rs
+++ b/crates/jsonschema/src/primitive_type.rs
@@ -154,7 +154,13 @@ impl Iterator for PrimitiveTypesBitMapIterator {
             Some(bit_map_representation_primitive_type(least_significant_bit))
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let count = self.bit_map.inner.count_ones() as usize;
+        (count, Some(count))
+    }
 }
+
+impl ExactSizeIterator for PrimitiveTypesBitMapIterator {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
```python
try:
    jsonschema_rs.validate({"maxItems": 2}, [1,2,3])
except Exception as exc:
    error = exc

print(a.kind.limit)
# 2
```