### PR TITLE
Ensure license file is published with each crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 authors = ["Dmitry Dygalo <dmitry@dygalo.dev>"]
 repository = "https://github.com/Stranger6667/jsonschema"
 license = "MIT"
+license-file = "LICENSE"
 
 [profile.release]
 lto = "fat"
@@ -45,4 +46,3 @@ rest_pat_in_fully_bound_structs = "warn"
 [workspace.metadata.typos]
 files.extend-exclude = ["*.json"]
 default.extend-ignore-re = ["propert"]
-

--- a/crates/benchmark-suite/Cargo.toml
+++ b/crates/benchmark-suite/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 publish = false
 
 [dev-dependencies]
@@ -33,4 +34,3 @@ name = "jsonschema_valid"
 [[bench]]
 harness = false
 name = "boon"
-

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 rust-version = "1.80"
 readme = "README.md"
 license.workspace = true
+license-file.workspace = true
 repository.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/jsonschema-cli/Cargo.toml
+++ b/crates/jsonschema-cli/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/jsonschema-py/Cargo.toml
+++ b/crates/jsonschema-py/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["jsonschema", "validation"]
 categories = ["web-programming"]
 readme = "README.md"
 license.workspace = true
+license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/crates/jsonschema-referencing-testsuite-codegen/Cargo.toml
+++ b/crates/jsonschema-referencing-testsuite-codegen/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/jsonschema-referencing-testsuite-internal/Cargo.toml
+++ b/crates/jsonschema-referencing-testsuite-internal/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/jsonschema-referencing-testsuite/Cargo.toml
+++ b/crates/jsonschema-referencing-testsuite/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 
 [dependencies]
 referencing_codegen = { package = "jsonschema-referencing-testsuite-codegen", path = "../jsonschema-referencing-testsuite-codegen/" }

--- a/crates/jsonschema-referencing/Cargo.toml
+++ b/crates/jsonschema-referencing/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 
 [dependencies]
 ahash.workspace = true

--- a/crates/jsonschema-testsuite-codegen/Cargo.toml
+++ b/crates/jsonschema-testsuite-codegen/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 publish = false
 
 [lib]

--- a/crates/jsonschema-testsuite-internal/Cargo.toml
+++ b/crates/jsonschema-testsuite-internal/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/jsonschema-testsuite/Cargo.toml
+++ b/crates/jsonschema-testsuite/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 rust-version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+license-file.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/jsonschema/Cargo.toml
+++ b/crates/jsonschema/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["jsonschema", "validation"]
 categories = ["web-programming"]
 readme = "../../README.md"
 license.workspace = true
+license-file.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 edition.workspace = true

--- a/crates/testsuite-common/Cargo.toml
+++ b/crates/testsuite-common/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+license-file.workspace = true
 
 [dependencies]
 syn = { version = "2", features = ["full"] }


### PR DESCRIPTION
As the license file is present at the root of the repository, it isn't part of any crate on crates.io, as those lie in subfolders. Ensure this file is published by telling cargo where to find it.