### PR TITLE
fix: multiple_of_float

### DIFF
--- a/crates/jsonschema/src/ext/numeric.rs
+++ b/crates/jsonschema/src/ext/numeric.rs
@@ -34,18 +34,11 @@ define_num_cmp!(
 
 pub(crate) fn is_multiple_of_float(value: &Number, multiple: f64) -> bool {
     let value = value.as_f64().expect("Always valid");
-    let remainder = (value / multiple) % 1.;
-    if remainder.is_nan() {
-        // Involves heap allocations via the underlying `BigUint` type
-        let fraction = BigFraction::from(value) / BigFraction::from(multiple);
-        if let Some(denom) = fraction.denom() {
-            denom.is_one()
-        } else {
-            true
-        }
-    } else {
-        remainder < f64::EPSILON
-    }
+    // Involves heap allocations via the underlying `BigUint` type
+    (BigFraction::from(value) / BigFraction::from(multiple))
+        .denom()
+        .map(|denom| denom.is_one())
+        .unwrap_or(true)
 }
 
 pub(crate) fn is_multiple_of_integer(value: &Number, multiple: f64) -> bool {

--- a/crates/jsonschema/src/keywords/multiple_of.rs
+++ b/crates/jsonschema/src/keywords/multiple_of.rs
@@ -125,6 +125,9 @@ mod tests {
     #[test_case(&json!({"multipleOf": 1.0}), &json!(4.0))]
     #[test_case(&json!({"multipleOf": 1.5}), &json!(3.0))]
     #[test_case(&json!({"multipleOf": 1.5}), &json!(4.5))]
+    #[test_case(&json!({"multipleOf": 0.1}), &json!(12.2))]
+    #[test_case(&json!({"multipleOf": 0.0001}), &json!(3.1254))]
+    #[test_case(&json!({"multipleOf": 0.0001}), &json!(47.498))]
     fn multiple_of_is_valid(schema: &Value, instance: &Value) {
         tests_util::is_valid(schema, instance)
     }


### PR DESCRIPTION
It appears that multiple issues have been reported regarding the validation of multipleOf for floating-point values. I have also identified a problem with the initial implementation of the remainder calculation: on my system, several (newly added) tests fail. Although the code implies that the results should fall within an EPSILON tolerance, the deviations are substantial. When BigFraction is used instead, all tests pass successfully.

value: 12.2 multipleOf:0.1 remainder:0.9999999999999858
value: 47.498 multipleOf:0.0001 remainder:0.9999999999417923
value: 3.1254 multipleOf:0.0001 remainder:0.999999999996362
