### PR TITLE
perf(referencing): avoid cloning static Values for meta-schemas

### DIFF
--- a/crates/jsonschema-referencing/src/meta.rs
+++ b/crates/jsonschema-referencing/src/meta.rs
@@ -79,7 +79,7 @@ schema!(
     pub DRAFT202012_CONTENT,
     "../metaschemas/draft2020-12/meta/content.json"
 );
-pub(crate) static META_SCHEMAS: Lazy<[(&'static str, &Value); 18]> = Lazy::new(|| {
+pub(crate) static META_SCHEMAS: Lazy<[(&'static str, &'static Value); 18]> = Lazy::new(|| {
     [
         ("http://json-schema.org/draft-04/schema#", &*DRAFT4),
         ("http://json-schema.org/draft-06/schema#", &*DRAFT6),

--- a/crates/jsonschema-referencing/src/resource.rs
+++ b/crates/jsonschema-referencing/src/resource.rs
@@ -92,6 +92,17 @@ impl<'a> ResourceRef<'a> {
     pub fn draft(&self) -> Draft {
         self.draft
     }
+
+    /// Create a resource-ref with automatically detecting specification which applies to the contents.
+    ///
+    /// # Errors
+    ///
+    /// On unknown `$schema` value it returns [`Error::UnknownSpecification`]
+    pub fn from_contents(contents: &'a Value) -> Result<Self, Error> {
+        let draft = Draft::default().detect(contents)?;
+        Ok(Self::new(contents, draft))
+    }
+
     #[must_use]
     pub fn id(&self) -> Option<&str> {
         JsonSchemaResource::id(self)


### PR DESCRIPTION
This tweaks the meta-schemas logic related to building lazy-static registries, in order to avoid cloning all the inner JSON Values which already have `'static` lifetimes.