### PR TITLE
feat: added support for string enums in object keys #453

### DIFF
--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for old and new style string enums in object keys.
+
 ### Changed
 
 - Update `pyo3` to `0.25`.


### PR DESCRIPTION
Resolves #453

In the end I chose to always use the `value` property in both old and new style enums