### PR TITLE
Add `context` field to `anyOf` and `oneOf` validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **CLI**: flag `-d, --draft <4|6|7|2019|2020>` to enforce a specific JSON Schema draft.
 - **CLI**: flags `--assert-format` and `--no-assert-format` to toggle validation of `format` keywords.
+- Added `context` for `ValidationErrorKind.AnyOf` and `ValidationErrorKind.OneOfNotValid` which contains errors for all subschemas, each inside a separate vector with an index matching subschema ID.
 
 ### Fixed
 

--- a/crates/benchmark-suite/benches/boon.rs
+++ b/crates/benchmark-suite/benches/boon.rs
@@ -8,7 +8,7 @@ fn bench_build(c: &mut Criterion, name: &str, schema: &Value) {
     compiler
         .add_resource("schema.json", schema.clone())
         .expect("Failed to add resource");
-    c.bench_function(&format!("boon/{}/build", name), |b| {
+    c.bench_function(&format!("boon/{name}/build"), |b| {
         b.iter(|| {
             compiler
                 .compile("schema.json", &mut Schemas::new())

--- a/crates/benchmark-suite/benches/jsonschema.rs
+++ b/crates/benchmark-suite/benches/jsonschema.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use serde_json::Value;
 
 fn bench_build(c: &mut Criterion, name: &str, schema: &Value) {
-    c.bench_function(&format!("jsonschema/{}/build", name), |b| {
+    c.bench_function(&format!("jsonschema/{name}/build"), |b| {
         b.iter_with_large_drop(|| jsonschema::validator_for(schema).expect("Valid schema"))
     });
 }

--- a/crates/benchmark-suite/benches/jsonschema_valid.rs
+++ b/crates/benchmark-suite/benches/jsonschema_valid.rs
@@ -4,7 +4,7 @@ use jsonschema_valid::{schemas, Config};
 use serde_json::Value;
 
 fn bench_build(c: &mut Criterion, name: &str, schema: &Value) {
-    c.bench_function(&format!("jsonschema_valid/{}/build", name), |b| {
+    c.bench_function(&format!("jsonschema_valid/{name}/build"), |b| {
         b.iter_with_large_drop(|| {
             Config::from_schema(schema, Some(schemas::Draft::Draft7)).expect("Valid schema")
         })

--- a/crates/benchmark-suite/benches/valico.rs
+++ b/crates/benchmark-suite/benches/valico.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use valico::json_schema;
 
 fn bench_build(c: &mut Criterion, name: &str, schema: &Value) {
-    c.bench_function(&format!("valico/{}/build", name), |b| {
+    c.bench_function(&format!("valico/{name}/build"), |b| {
         b.iter_batched(
             || (json_schema::Scope::new(), schema.clone()),
             |(mut scope, schema)| {

--- a/crates/benchmark/src/lib.rs
+++ b/crates/benchmark/src/lib.rs
@@ -139,7 +139,7 @@ pub fn run_keyword_benchmarks(bench: &mut BenchFunc) {
                 .iter()
                 .enumerate()
                 .map(|(idx, instance)| BenchInstance {
-                    name: format!("{}/{}", prefix, idx),
+                    name: format!("{prefix}/{idx}"),
                     data: instance.clone(),
                 })
                 .collect();

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added support for old and new style string enums in object keys.
+- Added `context` for `ValidationErrorKind.AnyOf` and `ValidationErrorKind.OneOfNotValid` which contains errors for all subschemas, each inside a separate list with an index matching subschema ID.
 
 ### Changed
 

--- a/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
+++ b/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
@@ -72,7 +72,7 @@ class ValidationErrorKind:
         unexpected: list[str]
 
     class AnyOf:
-        errors: list["ValidationError"]
+        context: list[list["ValidationError"]]
 
     class BacktrackLimitExceeded:
         error: str

--- a/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
+++ b/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
@@ -139,7 +139,9 @@ class ValidationErrorKind:
         schema: JSONType
 
     class OneOfMultipleValid: ...
-    class OneOfNotValid: ...
+
+    class OneOfNotValid:
+        errors: list["ValidationError"]
 
     class Pattern:
         pattern: str

--- a/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
+++ b/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
@@ -71,7 +71,8 @@ class ValidationErrorKind:
     class AdditionalProperties:
         unexpected: list[str]
 
-    class AnyOf: ...
+    class AnyOf:
+        errors: list["ValidationError"]
 
     class BacktrackLimitExceeded:
         error: str

--- a/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
+++ b/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
@@ -141,7 +141,7 @@ class ValidationErrorKind:
     class OneOfMultipleValid: ...
 
     class OneOfNotValid:
-        errors: list["ValidationError"]
+        context: list[list["ValidationError"]]
 
     class Pattern:
         pattern: str

--- a/crates/jsonschema-py/src/lib.rs
+++ b/crates/jsonschema-py/src/lib.rs
@@ -255,7 +255,7 @@ impl ValidationErrorKind {
                                 verbose_message,
                                 schema_path,
                                 instance_path,
-                                kind: Py::new(py, kind)?,
+                                kind: kind.into_pyobject(py)?.unbind(),
                                 instance,
                             },
                         )?

--- a/crates/jsonschema-py/src/lib.rs
+++ b/crates/jsonschema-py/src/lib.rs
@@ -105,7 +105,7 @@ impl ReferencingError {
 enum ValidationErrorKind {
     AdditionalItems { limit: usize },
     AdditionalProperties { unexpected: Py<PyList> },
-    AnyOf {},
+    AnyOf { errors: Py<PyList> },
     BacktrackLimitExceeded { error: String },
     Constant { expected_value: PyObject },
     Contains {},
@@ -155,7 +155,34 @@ impl ValidationErrorKind {
                     unexpected: PyList::new(py, unexpected)?.unbind(),
                 }
             }
-            jsonschema::error::ValidationErrorKind::AnyOf => ValidationErrorKind::AnyOf {},
+            jsonschema::error::ValidationErrorKind::AnyOf { errors } => {
+                ValidationErrorKind::AnyOf {
+                    errors: {
+                        let mut py_errors: Vec<Py<ValidationError>> = Vec::with_capacity(errors.len());
+
+                        for error in errors {
+                            let (message, verbose_message, schema_path, instance_path, kind, instance) =
+                                into_validation_error_args(py, error, mask)?;
+
+                            py_errors.push(
+                                Py::new(
+                                    py,
+                                    ValidationError {
+                                        message,
+                                        verbose_message,
+                                        schema_path,
+                                        instance_path,
+                                        kind: kind.into_pyobject(py)?.unbind(),
+                                        instance,
+                                    },
+                                )?
+                            );
+                        }
+
+                        PyList::new(py, py_errors)?.unbind()
+                    },
+                }
+            }
             jsonschema::error::ValidationErrorKind::BacktrackLimitExceeded { error } => {
                 ValidationErrorKind::BacktrackLimitExceeded {
                     error: error.to_string(),

--- a/crates/jsonschema-py/src/lib.rs
+++ b/crates/jsonschema-py/src/lib.rs
@@ -505,8 +505,7 @@ fn make_options(
         for (name, callback) in formats.iter() {
             if !callback.is_callable() {
                 return Err(exceptions::PyValueError::new_err(format!(
-                    "Format checker for '{}' must be a callable",
-                    name
+                    "Format checker for '{name}' must be a callable",
                 )));
             }
             let callback: Py<PyAny> = callback.clone().unbind();
@@ -828,7 +827,7 @@ fn handle_format_checked_panic(err: Box<dyn Any + Send>) -> PyErr {
             let _ = panic::take_hook();
             err
         } else {
-            exceptions::PyRuntimeError::new_err(format!("Validation panicked: {:?}", err))
+            exceptions::PyRuntimeError::new_err(format!("Validation panicked: {err:?}"))
         }
     })
 }
@@ -896,7 +895,7 @@ fn validator_for_impl(
         let ptr = unsafe { PyUnicode_AsUTF8AndSize(obj_ptr, &mut str_size) };
         let slice = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), str_size as usize) };
         serde_json::from_slice(slice)
-            .map_err(|error| PyValueError::new_err(format!("Invalid string: {}", error)))?
+            .map_err(|error| PyValueError::new_err(format!("Invalid string: {error}")))?
     } else {
         ser::to_value(schema)?
     };

--- a/crates/jsonschema-referencing-testsuite-codegen/src/generator.rs
+++ b/crates/jsonschema-referencing-testsuite-codegen/src/generator.rs
@@ -30,7 +30,7 @@ pub(crate) fn generate_modules(
                 let full_test_path = case_path.join("::");
                 let should_ignore = xfail.iter().any(|x| full_test_path.starts_with(x));
                 let ignore_attr = if should_ignore {
-                    quote! { #[ignore] }
+                    quote! { #[ignore = "xfail"] }
                 } else {
                     quote! {}
                 };

--- a/crates/jsonschema-testsuite-codegen/src/idents.rs
+++ b/crates/jsonschema-testsuite-codegen/src/idents.rs
@@ -5,7 +5,7 @@ pub(crate) fn get_unique(base: &str, used: &mut HashSet<String>) -> String {
     let mut counter = 1;
 
     while !used.insert(name.clone()) {
-        name = format!("{}_{}", base, counter);
+        name = format!("{base}_{counter}");
         counter += 1;
     }
 

--- a/crates/jsonschema/benches/keywords.rs
+++ b/crates/jsonschema/benches/keywords.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use serde_json::Value;
 
 fn bench_keyword_build(c: &mut Criterion, name: &str, schema: &Value) {
-    c.bench_function(&format!("keyword/{}/build", name), |b| {
+    c.bench_function(&format!("keyword/{name}/build"), |b| {
         b.iter_with_large_drop(|| jsonschema::validator_for(schema).expect("Valid schema"))
     });
 }
@@ -11,7 +11,7 @@ fn bench_keyword_build(c: &mut Criterion, name: &str, schema: &Value) {
 fn bench_keyword_is_valid(c: &mut Criterion, name: &str, schema: &Value, instance: &Value) {
     let validator = jsonschema::validator_for(schema).expect("Valid schema");
     c.bench_with_input(
-        BenchmarkId::new(format!("keyword/{}", name), "is_valid"),
+        BenchmarkId::new(format!("keyword/{name}"), "is_valid"),
         instance,
         |b, instance| {
             b.iter(|| {
@@ -24,7 +24,7 @@ fn bench_keyword_is_valid(c: &mut Criterion, name: &str, schema: &Value, instanc
 fn bench_keyword_validate(c: &mut Criterion, name: &str, schema: &Value, instance: &Value) {
     let validator = jsonschema::validator_for(schema).expect("Valid schema");
     c.bench_with_input(
-        BenchmarkId::new(format!("keyword/{}", name), "validate"),
+        BenchmarkId::new(format!("keyword/{name}"), "validate"),
         instance,
         |b, instance| {
             b.iter(|| {

--- a/crates/jsonschema/src/error.rs
+++ b/crates/jsonschema/src/error.rs
@@ -781,13 +781,13 @@ fn write_quoted_list(f: &mut Formatter<'_>, items: &[impl fmt::Display]) -> fmt:
     let mut iter = items.iter();
     if let Some(item) = iter.next() {
         f.write_char('\'')?;
-        write!(f, "{}", item)?;
+        write!(f, "{item}")?;
         f.write_char('\'')?;
     }
     for item in iter {
         f.write_str(", ")?;
         f.write_char('\'')?;
-        write!(f, "{}", item)?;
+        write!(f, "{item}")?;
         f.write_char('\'')?;
     }
     Ok(())
@@ -817,11 +817,11 @@ impl fmt::Display for ValidationError<'_> {
                 let mut iter = array.iter().skip(*limit);
 
                 if let Some(item) = iter.next() {
-                    write!(f, "{}", item)?;
+                    write!(f, "{item}")?;
                 }
                 for item in iter {
                     f.write_str(", ")?;
-                    write!(f, "{}", item)?;
+                    write!(f, "{item}")?;
                 }
 
                 write_unexpected_suffix(f, array.len() - limit)
@@ -847,7 +847,7 @@ impl fmt::Display for ValidationError<'_> {
                 self.instance
             ),
             ValidationErrorKind::Constant { expected_value } => {
-                write!(f, "{} was expected", expected_value)
+                write!(f, "{expected_value} was expected")
             }
             ValidationErrorKind::ContentEncoding { content_encoding } => {
                 write!(
@@ -943,7 +943,7 @@ impl fmt::Display for ValidationError<'_> {
             }
             ValidationErrorKind::PropertyNames { error } => error.fmt(f),
             ValidationErrorKind::Required { property } => {
-                write!(f, "{} is a required property", property)
+                write!(f, "{property} is a required property")
             }
             ValidationErrorKind::MultipleOf { multiple_of } => {
                 write!(f, "{} is not a multiple of {}", self.instance, multiple_of)
@@ -971,13 +971,13 @@ impl fmt::Display for ValidationError<'_> {
                 let mut iter = types.iter();
                 if let Some(t) = iter.next() {
                     f.write_char('"')?;
-                    write!(f, "{}", t)?;
+                    write!(f, "{t}")?;
                     f.write_char('"')?;
                 }
                 for t in iter {
                     f.write_str(", ")?;
                     f.write_char('"')?;
-                    write!(f, "{}", t)?;
+                    write!(f, "{t}")?;
                     f.write_char('"')?;
                 }
                 Ok(())
@@ -1026,7 +1026,7 @@ impl fmt::Display for MaskedValidationError<'_, '_, '_> {
                 self.placeholder
             ),
             ValidationErrorKind::Constant { expected_value } => {
-                write!(f, "{} was expected", expected_value)
+                write!(f, "{expected_value} was expected")
             }
             ValidationErrorKind::ContentEncoding { content_encoding } => {
                 write!(
@@ -1126,7 +1126,7 @@ impl fmt::Display for MaskedValidationError<'_, '_, '_> {
             }
             ValidationErrorKind::PropertyNames { error } => error.fmt(f),
             ValidationErrorKind::Required { property } => {
-                write!(f, "{} is a required property", property)
+                write!(f, "{property} is a required property")
             }
             ValidationErrorKind::MultipleOf { multiple_of } => {
                 write!(
@@ -1160,13 +1160,13 @@ impl fmt::Display for MaskedValidationError<'_, '_, '_> {
                 let mut iter = types.iter();
                 if let Some(t) = iter.next() {
                     f.write_char('"')?;
-                    write!(f, "{}", t)?;
+                    write!(f, "{t}")?;
                     f.write_char('"')?;
                 }
                 for t in iter {
                     f.write_str(", ")?;
                     f.write_char('"')?;
-                    write!(f, "{}", t)?;
+                    write!(f, "{t}")?;
                     f.write_char('"')?;
                 }
                 Ok(())

--- a/crates/jsonschema/src/error.rs
+++ b/crates/jsonschema/src/error.rs
@@ -149,7 +149,7 @@ pub enum ValidationErrorKind {
     OneOfMultipleValid,
     /// The given schema is not valid under any of the schemas listed in the 'oneOf' keyword.
     OneOfNotValid {
-        errors: Vec<ValidationError<'static>>,
+        context: Vec<Vec<ValidationError<'static>>>,
     },
     /// When the input doesn't match to a pattern.
     Pattern { pattern: String },
@@ -616,13 +616,16 @@ impl<'a> ValidationError<'a> {
         location: Location,
         instance_path: Location,
         instance: &'a Value,
-        errors: Vec<ValidationError<'a>>,
+        context: Vec<Vec<ValidationError<'a>>>,
     ) -> ValidationError<'a> {
         ValidationError {
             instance_path,
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::OneOfNotValid {
-                errors: errors.into_iter().map(|error| error.to_owned()).collect(),
+                context: context
+                    .into_iter()
+                    .map(|errors| errors.into_iter().map(|error| error.to_owned()).collect())
+                    .collect(),
             },
             schema_path: location,
         }
@@ -833,7 +836,7 @@ impl fmt::Display for ValidationError<'_> {
                 "{} is not valid under any of the schemas listed in the 'anyOf' keyword",
                 self.instance
             ),
-            ValidationErrorKind::OneOfNotValid { errors: _ } => write!(
+            ValidationErrorKind::OneOfNotValid { context: _ } => write!(
                 f,
                 "{} is not valid under any of the schemas listed in the 'oneOf' keyword",
                 self.instance
@@ -1012,7 +1015,7 @@ impl fmt::Display for MaskedValidationError<'_, '_, '_> {
                 "{} is not valid under any of the schemas listed in the 'anyOf' keyword",
                 self.placeholder
             ),
-            ValidationErrorKind::OneOfNotValid { errors: _ } => write!(
+            ValidationErrorKind::OneOfNotValid { context: _ } => write!(
                 f,
                 "{} is not valid under any of the schemas listed in the 'oneOf' keyword",
                 self.placeholder

--- a/crates/jsonschema/src/keywords/any_of.rs
+++ b/crates/jsonschema/src/keywords/any_of.rs
@@ -50,6 +50,10 @@ impl Validate for AnyOfValidator {
                 self.location.clone(),
                 location.into(),
                 instance,
+                self.schemas
+                    .iter()
+                    .flat_map(|schema| schema.iter_errors(instance, location))
+                    .collect(),
             ))
         }
     }
@@ -70,6 +74,10 @@ impl Validate for AnyOfValidator {
                 self.location.clone(),
                 location.into(),
                 instance,
+                self.schemas
+                    .iter()
+                    .flat_map(|schema| schema.iter_errors(instance, location))
+                    .collect(),
             ))
         }
     }

--- a/crates/jsonschema/src/keywords/any_of.rs
+++ b/crates/jsonschema/src/keywords/any_of.rs
@@ -52,7 +52,7 @@ impl Validate for AnyOfValidator {
                 instance,
                 self.schemas
                     .iter()
-                    .flat_map(|schema| schema.iter_errors(instance, location))
+                    .map(|schema| schema.iter_errors(instance, location).collect())
                     .collect(),
             ))
         }
@@ -76,7 +76,7 @@ impl Validate for AnyOfValidator {
                 instance,
                 self.schemas
                     .iter()
-                    .flat_map(|schema| schema.iter_errors(instance, location))
+                    .map(|schema| schema.iter_errors(instance, location).collect())
                     .collect(),
             ))
         }

--- a/crates/jsonschema/src/keywords/one_of.rs
+++ b/crates/jsonschema/src/keywords/one_of.rs
@@ -88,6 +88,10 @@ impl Validate for OneOfValidator {
                 self.location.clone(),
                 location.into(),
                 instance,
+                self.schemas
+                    .iter()
+                    .flat_map(|schema| schema.iter_errors(instance, location))
+                    .collect(),
             ))
         }
     }

--- a/crates/jsonschema/src/keywords/one_of.rs
+++ b/crates/jsonschema/src/keywords/one_of.rs
@@ -90,7 +90,7 @@ impl Validate for OneOfValidator {
                 instance,
                 self.schemas
                     .iter()
-                    .flat_map(|schema| schema.iter_errors(instance, location))
+                    .map(|schema| schema.iter_errors(instance, location).collect())
                     .collect(),
             ))
         }

--- a/crates/jsonschema/src/keywords/ref_.rs
+++ b/crates/jsonschema/src/keywords/ref_.rs
@@ -645,7 +645,7 @@ mod tests {
             .build(&schema)
         {
             Ok(validator) => validator,
-            Err(error) => panic!("Failed to build validator: {}", error),
+            Err(error) => panic!("Failed to build validator: {error}"),
         };
 
         assert!(validator.is_valid(&json!("test")));
@@ -691,7 +691,7 @@ mod tests {
             .build(&schema)
         {
             Ok(validator) => validator,
-            Err(error) => panic!("Failed to build validator: {}", error),
+            Err(error) => panic!("Failed to build validator: {error}"),
         };
 
         assert!(validator.is_valid(&json!(42)));

--- a/crates/jsonschema/src/lib.rs
+++ b/crates/jsonschema/src/lib.rs
@@ -1855,23 +1855,19 @@ pub(crate) mod tests_util {
     pub(crate) fn is_not_valid_with(validator: &Validator, instance: &Value) {
         assert!(
             !validator.is_valid(instance),
-            "{} should not be valid (via is_valid)",
-            instance
+            "{instance} should not be valid (via is_valid)",
         );
         assert!(
             validator.validate(instance).is_err(),
-            "{} should not be valid (via validate)",
-            instance
+            "{instance} should not be valid (via validate)",
         );
         assert!(
             validator.iter_errors(instance).next().is_some(),
-            "{} should not be valid (via validate)",
-            instance
+            "{instance} should not be valid (via validate)",
         );
         assert!(
             !validator.apply(instance).basic().is_valid(),
-            "{} should not be valid (via apply)",
-            instance
+            "{instance} should not be valid (via apply)",
         );
     }
 
@@ -1915,18 +1911,15 @@ pub(crate) mod tests_util {
         }
         assert!(
             validator.is_valid(instance),
-            "{} should be valid (via is_valid)",
-            instance
+            "{instance} should be valid (via is_valid)",
         );
         assert!(
             validator.validate(instance).is_ok(),
-            "{} should be valid (via is_valid)",
-            instance
+            "{instance} should be valid (via is_valid)",
         );
         assert!(
             validator.apply(instance).basic().is_valid(),
-            "{} should be valid (via apply)",
-            instance
+            "{instance} should be valid (via apply)",
         );
     }
 

--- a/crates/jsonschema/src/paths.rs
+++ b/crates/jsonschema/src/paths.rs
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_display_trait() {
         let loc = Location::new().join("property");
-        assert_eq!(format!("{}", loc), "/property");
+        assert_eq!(format!("{loc}"), "/property");
     }
 
     #[test_case("tilde~character", "/tilde~0character"; "escapes tilde")]

--- a/crates/jsonschema/src/retriever.rs
+++ b/crates/jsonschema/src/retriever.rs
@@ -190,7 +190,7 @@ mod tests {
             },
             "required": ["name"]
         });
-        write!(temp_file, "{}", external_schema).expect("Failed to write to temp file");
+        write!(temp_file, "{external_schema}").expect("Failed to write to temp file");
 
         let uri = path_to_uri(temp_file.path());
 
@@ -296,7 +296,7 @@ mod async_tests {
             },
             "required": ["name"]
         });
-        write!(temp_file, "{}", external_schema).expect("Failed to write to temp file");
+        write!(temp_file, "{external_schema}").expect("Failed to write to temp file");
 
         let uri = path_to_uri(temp_file.path());
 
@@ -365,7 +365,7 @@ mod async_tests {
                     "field": { "type": "string", "minLength": i }
                 }
             });
-            write!(temp_file, "{}", schema).expect("Failed to write to temp file");
+            write!(temp_file, "{schema}").expect("Failed to write to temp file");
             uris.push(path_to_uri(temp_file.path()));
             temp_files.push(temp_file);
         }

--- a/crates/jsonschema/tests/output.rs
+++ b/crates/jsonschema/tests/output.rs
@@ -1014,6 +1014,6 @@ fn test_additional_properties_basic_output(
     if &output != expected {
         let expected_str = serde_json::to_string_pretty(expected).unwrap();
         let actual_str = serde_json::to_string_pretty(&output).unwrap();
-        panic!("\nExpected:\n{}\n\nGot:\n{}\n", expected_str, actual_str);
+        panic!("\nExpected:\n{expected_str}\n\nGot:\n{actual_str}\n");
     }
 }

--- a/crates/jsonschema/tests/suite.rs
+++ b/crates/jsonschema/tests/suite.rs
@@ -164,8 +164,8 @@ mod tests {
         let expectations: serde_json::Value =
             serde_json::from_str(include_str!("draft7_instance_paths.json")).expect("Valid JSON");
         for (filename, expected) in expectations.as_object().expect("Is object") {
-            let test_file = fs::read_to_string(format!("tests/suite/tests/draft7/{}", filename))
-                .unwrap_or_else(|_| panic!("Valid file: {}", filename));
+            let test_file = fs::read_to_string(format!("tests/suite/tests/draft7/{filename}"))
+                .unwrap_or_else(|_| panic!("Valid file: {filename}"));
             let data: serde_json::Value = serde_json::from_str(&test_file).expect("Valid JSON");
             for item in expected.as_array().expect("Is array") {
                 let suite_id = item["suite_id"].as_u64().expect("Is integer") as usize;
@@ -175,8 +175,7 @@ mod tests {
                     .build(schema)
                     .unwrap_or_else(|_| {
                         panic!(
-                            "Valid schema. File: {}; Suite ID: {}; Schema: {}",
-                            filename, suite_id, schema
+                            "Valid schema. File: {filename}; Suite ID: {suite_id}; Schema: {schema}",
                         )
                     });
                 for test_data in item["tests"].as_array().expect("Valid array") {


### PR DESCRIPTION
Fixes https://github.com/Stranger6667/jsonschema/issues/649

Hi, thank you for this awesome library! We are currently using the Python `jsonschema` library, and we want to switch to the `jsonschema-rs`, but we are blocked by one missing feature, which is the context for the `anyOf` and `oneOf` validation. We are currently using the `context` present in the `anyOf` and `oneOf` to provide better errors for our end-users.

Now I do understand that collecting those additional errors for the context of `anyOf` and `oneOf` can have an impact on the performance, so I went with the route of minimizing additional allocations and code branches for the happy path by simply collecting those errors only in case of an error during the validation. This does mean that the validation is executed again in order to collect errors, but it also avoids calling `.iter_errors()` instead of `.is_valid()` for the happy path, during which we actually want the most performance. I think this additional overhead should be fine for the unhappy path, as it should be hit rarely in the production systems, and it should greatly improve the user experience when the error happens.

If you have a different idea how to solve this, I'm willing to work on this, as this is essential for us to switch to `jsonschema-rs`. The only thing right now that I don't like with this approach is that those errors are eventually converted to `'static` objects, which live for the whole duration of the program because `ValidationErrorKind` does not have a lifetime. This could lead to leaking memory every time we hit the validation error for the `anyOf` or `oneOf`. I started tinkering with the idea of adding lifetime to `ValidationErrorKind`, but it does not seem to be so trivial. Please let me know what you think about that.

Also, during the development of this, I found one small bug in the Python bindings (as I made the same mistake myself) and added a simple fix for it in a separate commit, see below:
- https://github.com/PyO3/pyo3/issues/3747
- https://pyo3.rs/v0.25.1/class#complex-enums.

> WARNING: Py::new and .into_pyobject are currently inconsistent. Note how the constructed value is not an instance of the specific variant. For this reason, constructing values is only recommended using .into_pyobject.