### PR TITLE
fix: `instance_path` segments are now unescaped when iterating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING**: `instance_path` segments are now unescaped when iterating. `LocationSegment::Property` now holds `Cow<'_, str>` and `LocationSegment` is no longer `Copy`. [#788](https://github.com/Stranger6667/jsonschema/issues/788)
+
 ## [0.32.1] - 2025-08-03
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,31 @@
 # Migration Guide
 
+## Upgrading from 0.32.x to 0.33.0 note
+
+In 0.33 `LocationSegment::Property` now holds a `Cow<'_, str>` and `LocationSegment` is no longer `Copy`. 
+
+If your code matches the enum and treats the property as `&str`, update it like this.
+
+This change was made to support proper round-trips for JSON Pointer segments (escaped vs. unescaped forms).
+
+```rust
+// Old (0.32.x)
+match segment {
+    LocationSegment::Property(p) => do_something(p), // p: &str
+    LocationSegment::Index(i)    => ...
+}
+
+do_something_else(segment);
+
+// New (0.33.0)
+match segment {
+    LocationSegment::Property(p) => do_something(&*p), // p: Cow<'_, str>
+    LocationSegment::Index(i)    => ...
+}
+
+// `LocationSegment` is no longer Copy, use `.clone()` if you need ownership
+do_something_else(segment.clone());
+```
 
 ## Upgrading from 0.29.x to 0.30.0
 

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `instance_path` segments are now unescaped when iterating. [#788](https://github.com/Stranger6667/jsonschema/issues/788)
+
 ## [0.32.1] - 2025-08-03
 
 ### Changed

--- a/crates/jsonschema-referencing/src/anchors/keys.rs
+++ b/crates/jsonschema-referencing/src/anchors/keys.rs
@@ -48,11 +48,11 @@ impl<'a> AnchorKeyRef<'a> {
 }
 
 pub(crate) trait BorrowDyn {
-    fn borrowed_key(&self) -> AnchorKeyRef;
+    fn borrowed_key(&self) -> AnchorKeyRef<'_>;
 }
 
 impl BorrowDyn for AnchorKey {
-    fn borrowed_key(&self) -> AnchorKeyRef {
+    fn borrowed_key(&self) -> AnchorKeyRef<'_> {
         AnchorKeyRef::new(&self.uri, self.name.as_str())
     }
 }

--- a/crates/jsonschema-referencing/src/registry.rs
+++ b/crates/jsonschema-referencing/src/registry.rs
@@ -474,13 +474,13 @@ impl Registry {
     /// # Errors
     ///
     /// Returns an error if the base URI is invalid.
-    pub fn try_resolver(&self, base_uri: &str) -> Result<Resolver, Error> {
+    pub fn try_resolver(&self, base_uri: &str) -> Result<Resolver<'_>, Error> {
         let base = uri::from_str(base_uri)?;
         Ok(self.resolver(base))
     }
     /// Create a new [`Resolver`] for this registry with a known valid base URI.
     #[must_use]
-    pub fn resolver(&self, base_uri: Uri<String>) -> Resolver {
+    pub fn resolver(&self, base_uri: Uri<String>) -> Resolver<'_> {
         Resolver::new(self, Arc::new(base_uri))
     }
     #[must_use]
@@ -488,7 +488,7 @@ impl Registry {
         &self,
         base_uri: Arc<Uri<String>>,
         scopes: List<Uri<String>>,
-    ) -> Resolver {
+    ) -> Resolver<'_> {
         Resolver::from_parts(self, base_uri, scopes)
     }
     pub(crate) fn anchor<'a>(&self, uri: &'a Uri<String>, name: &'a str) -> Result<&Anchor, Error> {

--- a/crates/jsonschema-referencing/src/resource.rs
+++ b/crates/jsonschema-referencing/src/resource.rs
@@ -225,7 +225,7 @@ impl JsonSchemaResource for InnerResourcePtr {
 
 /// Unescape JSON Pointer path segments by converting `~1` to `/` and `~0` to `~`.
 #[must_use]
-pub fn unescape_segment(mut segment: &str) -> Cow<str> {
+pub fn unescape_segment(mut segment: &str) -> Cow<'_, str> {
     // Naively, checking for `~` and then replacing implies two passes
     // over the input buffer. First, search in the first `contains('~')` call
     // and then replacing `~1` & `~0` at once in a single pass.

--- a/crates/jsonschema/benches/location.rs
+++ b/crates/jsonschema/benches/location.rs
@@ -27,9 +27,9 @@ fn benchmark_into_iterator(c: &mut Criterion) {
 fn benchmark_from_iterator(c: &mut Criterion) {
     let empty = vec![];
     let small = vec![
-        LocationSegment::Property("a"),
-        LocationSegment::Property("b"),
-        LocationSegment::Property("c"),
+        LocationSegment::from("a"),
+        LocationSegment::from("b"),
+        LocationSegment::from("c"),
     ];
     let large = (0..1000)
         .map(|_| LocationSegment::from("abc"))

--- a/crates/jsonschema/src/keywords/const_.rs
+++ b/crates/jsonschema/src/keywords/const_.rs
@@ -12,7 +12,7 @@ struct ConstArrayValidator {
 }
 impl ConstArrayValidator {
     #[inline]
-    pub(crate) fn compile(value: &[Value], location: Location) -> CompilationResult {
+    pub(crate) fn compile(value: &[Value], location: Location) -> CompilationResult<'_> {
         Ok(Box::new(ConstArrayValidator {
             value: value.to_vec(),
             location,
@@ -125,7 +125,7 @@ struct ConstNumberValidator {
 
 impl ConstNumberValidator {
     #[inline]
-    pub(crate) fn compile(original_value: &Number, location: Location) -> CompilationResult {
+    pub(crate) fn compile(original_value: &Number, location: Location) -> CompilationResult<'_> {
         Ok(Box::new(ConstNumberValidator {
             original_value: original_value.clone(),
             value: original_value
@@ -170,7 +170,7 @@ pub(crate) struct ConstObjectValidator {
 
 impl ConstObjectValidator {
     #[inline]
-    pub(crate) fn compile(value: &Map<String, Value>, location: Location) -> CompilationResult {
+    pub(crate) fn compile(value: &Map<String, Value>, location: Location) -> CompilationResult<'_> {
         Ok(Box::new(ConstObjectValidator {
             value: value.clone(),
             location,
@@ -211,7 +211,7 @@ pub(crate) struct ConstStringValidator {
 
 impl ConstStringValidator {
     #[inline]
-    pub(crate) fn compile(value: &str, location: Location) -> CompilationResult {
+    pub(crate) fn compile(value: &str, location: Location) -> CompilationResult<'_> {
         Ok(Box::new(ConstStringValidator {
             value: value.to_string(),
             location,

--- a/crates/jsonschema/src/keywords/content.rs
+++ b/crates/jsonschema/src/keywords/content.rs
@@ -24,7 +24,7 @@ impl ContentMediaTypeValidator {
         media_type: &str,
         func: ContentMediaTypeCheckType,
         location: Location,
-    ) -> CompilationResult {
+    ) -> CompilationResult<'_> {
         Ok(Box::new(ContentMediaTypeValidator {
             media_type: media_type.to_string(),
             func,
@@ -78,7 +78,7 @@ impl ContentEncodingValidator {
         encoding: &str,
         func: ContentEncodingCheckType,
         location: Location,
-    ) -> CompilationResult {
+    ) -> CompilationResult<'_> {
         Ok(Box::new(ContentEncodingValidator {
             encoding: encoding.to_string(),
             func,

--- a/crates/jsonschema/src/keywords/legacy/type_draft_4.rs
+++ b/crates/jsonschema/src/keywords/legacy/type_draft_4.rs
@@ -16,7 +16,7 @@ pub(crate) struct MultipleTypesValidator {
 
 impl MultipleTypesValidator {
     #[inline]
-    pub(crate) fn compile(items: &[Value], location: Location) -> CompilationResult {
+    pub(crate) fn compile(items: &[Value], location: Location) -> CompilationResult<'_> {
         let mut types = JsonTypeSet::empty();
         for item in items {
             match item {

--- a/crates/jsonschema/src/keywords/required.rs
+++ b/crates/jsonschema/src/keywords/required.rs
@@ -15,7 +15,7 @@ pub(crate) struct RequiredValidator {
 
 impl RequiredValidator {
     #[inline]
-    pub(crate) fn compile(items: &[Value], location: Location) -> CompilationResult {
+    pub(crate) fn compile(items: &[Value], location: Location) -> CompilationResult<'_> {
         let mut required = Vec::with_capacity(items.len());
         for item in items {
             match item {
@@ -94,7 +94,7 @@ pub(crate) struct SingleItemRequiredValidator {
 
 impl SingleItemRequiredValidator {
     #[inline]
-    pub(crate) fn compile(value: &str, location: Location) -> CompilationResult {
+    pub(crate) fn compile(value: &str, location: Location) -> CompilationResult<'_> {
         Ok(Box::new(SingleItemRequiredValidator {
             value: value.to_string(),
             location,
@@ -140,7 +140,10 @@ pub(crate) fn compile<'a>(
 }
 
 #[inline]
-pub(crate) fn compile_with_path(schema: &Value, location: Location) -> Option<CompilationResult> {
+pub(crate) fn compile_with_path(
+    schema: &Value,
+    location: Location,
+) -> Option<CompilationResult<'_>> {
     // IMPORTANT: If this function will ever return `None`, adjust `dependencies.rs` accordingly
     match schema {
         Value::Array(items) => {

--- a/crates/jsonschema/src/keywords/type_.rs
+++ b/crates/jsonschema/src/keywords/type_.rs
@@ -18,7 +18,7 @@ pub(crate) struct MultipleTypesValidator {
 
 impl MultipleTypesValidator {
     #[inline]
-    pub(crate) fn compile(items: &[Value], location: Location) -> CompilationResult {
+    pub(crate) fn compile(items: &[Value], location: Location) -> CompilationResult<'_> {
         let mut types = JsonTypeSet::empty();
         for item in items {
             match item {

--- a/crates/jsonschema/src/lib.rs
+++ b/crates/jsonschema/src/lib.rs
@@ -985,7 +985,7 @@ pub mod meta {
     /// # Panics
     ///
     /// This function panics if the meta-schema can't be detected.
-    pub fn validate(schema: &Value) -> Result<(), ValidationError> {
+    pub fn validate(schema: &Value) -> Result<(), ValidationError<'_>> {
         meta_validator_for(schema).validate(schema)
     }
 
@@ -1055,7 +1055,9 @@ pub mod meta {
     /// });
     /// assert!(jsonschema::meta::try_validate(&undetectable_schema).is_err());
     /// ```
-    pub fn try_validate(schema: &Value) -> Result<Result<(), ValidationError>, ReferencingError> {
+    pub fn try_validate(
+        schema: &Value,
+    ) -> Result<Result<(), ValidationError<'_>>, ReferencingError> {
         Ok(try_meta_validator_for(schema)?.validate(schema))
     }
 
@@ -1220,7 +1222,7 @@ pub mod draft4 {
         /// assert!(jsonschema::draft4::meta::validate(&invalid_schema).is_err());
         /// ```
         #[inline]
-        pub fn validate(schema: &Value) -> Result<(), ValidationError> {
+        pub fn validate(schema: &Value) -> Result<(), ValidationError<'_>> {
             VALIDATOR.validate(schema)
         }
     }
@@ -1375,7 +1377,7 @@ pub mod draft6 {
         /// assert!(jsonschema::draft6::meta::validate(&invalid_schema).is_err());
         /// ```
         #[inline]
-        pub fn validate(schema: &Value) -> Result<(), ValidationError> {
+        pub fn validate(schema: &Value) -> Result<(), ValidationError<'_>> {
             VALIDATOR.validate(schema)
         }
     }
@@ -1530,7 +1532,7 @@ pub mod draft7 {
         /// assert!(jsonschema::draft7::meta::validate(&invalid_schema).is_err());
         /// ```
         #[inline]
-        pub fn validate(schema: &Value) -> Result<(), ValidationError> {
+        pub fn validate(schema: &Value) -> Result<(), ValidationError<'_>> {
             VALIDATOR.validate(schema)
         }
     }
@@ -1684,7 +1686,7 @@ pub mod draft201909 {
         /// assert!(jsonschema::draft201909::meta::validate(&invalid_schema).is_err());
         /// ```
         #[inline]
-        pub fn validate(schema: &Value) -> Result<(), ValidationError> {
+        pub fn validate(schema: &Value) -> Result<(), ValidationError<'_>> {
             VALIDATOR.validate(schema)
         }
     }
@@ -1842,7 +1844,7 @@ pub mod draft202012 {
         /// assert!(jsonschema::draft202012::meta::validate(&invalid_schema).is_err());
         /// ```
         #[inline]
-        pub fn validate(schema: &Value) -> Result<(), ValidationError> {
+        pub fn validate(schema: &Value) -> Result<(), ValidationError<'_>> {
             VALIDATOR.validate(schema)
         }
     }

--- a/crates/jsonschema/src/node.rs
+++ b/crates/jsonschema/src/node.rs
@@ -112,7 +112,11 @@ impl SchemaNode {
     /// validator tree and so rather than returning a `PartialApplication` it is able to return a
     /// complete `BasicOutput`. This is the mechanism which compositional validators use to combine
     /// results from sub-schemas
-    pub(crate) fn apply_rooted(&self, instance: &Value, location: &LazyLocation) -> BasicOutput {
+    pub(crate) fn apply_rooted(
+        &self,
+        instance: &Value,
+        location: &LazyLocation,
+    ) -> BasicOutput<'_> {
         match self.apply(instance, location) {
             PartialApplication::Valid {
                 annotations,


### PR DESCRIPTION
Fixes #788 