### PR TITLE
fix: Memory not reclaimed when a validator for a schema with recursive `$ref` or `$dynamicRef` is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Memory not reclaimed when a `Validator` for a schema with recursive `$ref` or `$dynamicRef` is dropped. [#1125](https://github.com/Stranger6667/jsonschema/issues/1125)
+
 ## [0.46.2] - 2026-04-20
 
 ### Fixed

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## [0.46.2] - 2026-04-20
-
 ## [Unreleased]
+
+### Fixed
+
+- Memory not reclaimed when a validator for a schema with recursive `$ref` or `$dynamicRef` is dropped. [#1125](https://github.com/Stranger6667/jsonschema/issues/1125)
+
+## [0.46.2] - 2026-04-20
 
 ### Fixed
 

--- a/crates/jsonschema-rb/CHANGELOG.md
+++ b/crates/jsonschema-rb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Memory not reclaimed when a validator for a schema with recursive `$ref` or `$dynamicRef` is dropped. [#1125](https://github.com/Stranger6667/jsonschema/issues/1125)
+
 ## [0.46.2] - 2026-04-20
 
 ### Fixed

--- a/crates/jsonschema/src/node.rs
+++ b/crates/jsonschema/src/node.rs
@@ -41,21 +41,11 @@ pub(crate) struct PendingSchemaNode {
     cell: Arc<OnceLock<PendingTarget>>,
 }
 
+#[derive(Debug)]
 struct PendingTarget {
     inner: Weak<SchemaNodeInner>,
     location: Location,
     absolute_path: Option<Arc<Uri<String>>>,
-    /// Cached materialized `SchemaNode` to avoid cloning on every access.
-    cached_node: OnceLock<SchemaNode>,
-}
-
-impl fmt::Debug for PendingTarget {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PendingTarget")
-            .field("location", &self.location)
-            .field("absolute_path", &self.absolute_path)
-            .finish_non_exhaustive()
-    }
 }
 
 enum NodeValidators {
@@ -124,15 +114,14 @@ impl PendingSchemaNode {
             inner: Arc::downgrade(&node.inner),
             location: node.location.clone(),
             absolute_path: node.absolute_path.clone(),
-            cached_node: OnceLock::new(),
         };
         self.cell
             .set(target)
             .expect("pending node initialized twice");
     }
 
-    pub(crate) fn get(&self) -> Option<&SchemaNode> {
-        self.cell.get().map(PendingTarget::get_or_materialize)
+    pub(crate) fn get(&self) -> Option<SchemaNode> {
+        self.cell.get().map(PendingTarget::materialize)
     }
 
     fn with_node<F, R>(&self, f: F) -> R
@@ -143,7 +132,8 @@ impl PendingSchemaNode {
             .cell
             .get()
             .expect("pending node accessed before initialization");
-        f(target.get_or_materialize())
+        let node = target.materialize();
+        f(&node)
     }
 
     /// Get a unique identifier for this pending node.
@@ -155,16 +145,13 @@ impl PendingSchemaNode {
 }
 
 impl PendingTarget {
-    /// Get or create the cached `SchemaNode`. Only clones on first access.
-    fn get_or_materialize(&self) -> &SchemaNode {
-        self.cached_node.get_or_init(|| {
-            let inner = self.inner.upgrade().expect("pending schema target dropped");
-            SchemaNode {
-                inner,
-                location: self.location.clone(),
-                absolute_path: self.absolute_path.clone(),
-            }
-        })
+    fn materialize(&self) -> SchemaNode {
+        let inner = self.inner.upgrade().expect("pending schema target dropped");
+        SchemaNode {
+            inner,
+            location: self.location.clone(),
+            absolute_path: self.absolute_path.clone(),
+        }
     }
 }
 

--- a/crates/jsonschema/tests/leak.rs
+++ b/crates/jsonschema/tests/leak.rs
@@ -1,0 +1,70 @@
+use jsonschema::{Keyword, ValidationError};
+use serde_json::{json, Value};
+use std::sync::{Arc, Weak};
+
+struct DropProbe;
+
+struct ProbeKeyword {
+    _probe: Arc<DropProbe>,
+}
+
+impl Keyword for ProbeKeyword {
+    fn validate<'i>(&self, _instance: &'i Value) -> Result<(), ValidationError<'i>> {
+        Ok(())
+    }
+
+    fn is_valid(&self, _instance: &Value) -> bool {
+        true
+    }
+}
+
+fn run_validator(probe: Arc<DropProbe>) {
+    let schema = json!({
+        "$defs": {
+            "Tree": {
+                "type": "object",
+                "leak-probe": true,
+                "properties": {
+                    "value": {"type": "integer"},
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Tree"}
+                    }
+                }
+            }
+        },
+        "$ref": "#/$defs/Tree"
+    });
+    let instance = json!({
+        "value": 1,
+        "children": [
+            {"value": 2, "children": []},
+            {"value": 3, "children": [{"value": 4, "children": []}]}
+        ]
+    });
+
+    let validator = jsonschema::options()
+        .with_keyword("leak-probe", move |_, _, _| {
+            Ok(Box::new(ProbeKeyword {
+                _probe: Arc::clone(&probe),
+            }))
+        })
+        .build(&schema)
+        .expect("schema must compile");
+
+    assert!(validator.is_valid(&instance));
+}
+
+#[test]
+fn recursive_validator_releases_tree_on_drop() {
+    // See GH-1125
+    let probe = Arc::new(DropProbe);
+    let weak: Weak<DropProbe> = Arc::downgrade(&probe);
+
+    run_validator(probe);
+
+    assert!(
+        weak.upgrade().is_none(),
+        "recursive validator tree leaked on drop",
+    );
+}


### PR DESCRIPTION
Fixes #1125 