### PR TITLE
fix: `pattern` validation errors displayed the internally translated regex instead of the original schema pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `prefixItems` incorrectly recognised as a known keyword in Draft 2019-09 and earlier (it is 2020-12 only).
+- `pattern` validation errors displayed the internally translated regex instead of the original schema pattern. [#1149](https://github.com/Stranger6667/jsonschema/issues/1149)
 
 ## [0.46.5] - 2026-05-13
 

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `prefixItems` incorrectly recognised as a known keyword in Draft 2019-09 and earlier (it is 2020-12 only).
+- `pattern` validation errors displayed the internally translated regex instead of the original schema pattern. [#1149](https://github.com/Stranger6667/jsonschema/issues/1149)
 
 ## [0.46.5] - 2026-05-13
 

--- a/crates/jsonschema-rb/CHANGELOG.md
+++ b/crates/jsonschema-rb/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `prefixItems` incorrectly recognised as a known keyword in Draft 2019-09 and earlier (it is 2020-12 only).
+- `pattern` validation errors displayed the internally translated regex instead of the original schema pattern. [#1149](https://github.com/Stranger6667/jsonschema/issues/1149)
 
 ## [0.46.5] - 2026-05-13
 

--- a/crates/jsonschema/src/keywords/pattern.rs
+++ b/crates/jsonschema/src/keywords/pattern.rs
@@ -174,6 +174,9 @@ impl Validate for NoWhitespacePatternValidator {
 
 pub(crate) struct PatternValidator<R> {
     regex: Arc<R>,
+    /// Original schema pattern, kept for error messages. The compiled `regex` stores the
+    /// ECMA->Rust translated form (e.g. `\S` expanded into a verbose class), which is unreadable.
+    pattern: String,
     location: Location,
 }
 
@@ -194,12 +197,12 @@ impl<R: RegexEngine> Validate for PatternValidator<R> {
                             crate::paths::capture_evaluation_path(tracker, &self.location),
                             location.into(),
                             instance,
-                            self.regex.pattern().to_string(),
+                            self.pattern.clone(),
                         ));
                     }
                 }
                 Err(e) => {
-                    let pattern = self.regex.pattern().to_string();
+                    let pattern = &self.pattern;
                     let tracker = crate::paths::capture_evaluation_path(tracker, &self.location);
                     return Err(match e.into_failure_reason() {
                         RegexFailureReason::FancyRegex(error) => ValidationError::backtrack_limit(
@@ -277,6 +280,7 @@ pub(crate) fn compile<'a>(
                 };
                 Some(Ok(Box::new(PatternValidator {
                     regex,
+                    pattern: item.clone(),
                     location: ctx.location().join("pattern"),
                 })))
             }
@@ -286,6 +290,7 @@ pub(crate) fn compile<'a>(
                 };
                 Some(Ok(Box::new(PatternValidator {
                     regex,
+                    pattern: item.clone(),
                     location: ctx.location().join("pattern"),
                 })))
             }
@@ -382,6 +387,33 @@ mod tests {
         let validator = crate::validator_for(&schema).unwrap();
         assert_eq!(validator.is_valid(&text), is_matching);
         assert_eq!(validator.validate(&text).is_ok(), is_matching);
+    }
+
+    // Error messages must show the original schema pattern, not the ECMA->Rust translated form
+    // (e.g. `\S` expanded into a verbose Unicode class).
+    fn assert_original_pattern_in_error(validator: &crate::Validator) {
+        let instance = json!("");
+        let error = validator
+            .validate(&instance)
+            .expect_err("expected a validation error");
+        assert_eq!(error.to_string(), r#""" does not match "^[\S]{1,5}$""#);
+    }
+
+    #[test]
+    fn original_pattern_in_error() {
+        let schema = json!({"pattern": r"^[\S]{1,5}$"});
+        assert_original_pattern_in_error(
+            &crate::options()
+                .with_pattern_options(PatternOptions::fancy_regex())
+                .build(&schema)
+                .expect("Schema should be valid"),
+        );
+        assert_original_pattern_in_error(
+            &crate::options()
+                .with_pattern_options(PatternOptions::regex())
+                .build(&schema)
+                .expect("Schema should be valid"),
+        );
     }
 
     #[test]

--- a/crates/jsonschema/src/keywords/pattern_properties.rs
+++ b/crates/jsonschema/src/keywords/pattern_properties.rs
@@ -276,21 +276,12 @@ fn try_compile_as_literals<'a>(
     for (pattern, subschema) in map {
         let pctx = ctx.new_at_location(pattern.as_str());
         let matcher = match analyze_pattern(pattern)? {
-            PatternOptimization::Prefix(literal) => LiteralMatcher::Prefix {
-                literal,
-                original: pattern.clone(),
-            },
-            PatternOptimization::Exact(exact) => LiteralMatcher::Exact {
-                exact,
-                original: pattern.clone(),
-            },
-            PatternOptimization::Alternation(alternatives) => LiteralMatcher::Alternation {
-                alternatives,
-                original: pattern.clone(),
-            },
-            PatternOptimization::NoWhitespace => LiteralMatcher::NoWhitespace {
-                original: pattern.clone(),
-            },
+            PatternOptimization::Prefix(literal) => LiteralMatcher::Prefix { literal },
+            PatternOptimization::Exact(exact) => LiteralMatcher::Exact { exact },
+            PatternOptimization::Alternation(alternatives) => {
+                LiteralMatcher::Alternation { alternatives }
+            }
+            PatternOptimization::NoWhitespace => LiteralMatcher::NoWhitespace,
         };
         let node = match compiler::compile(&pctx, pctx.as_resource_ref(subschema)) {
             Ok(node) => node,

--- a/crates/jsonschema/src/properties.rs
+++ b/crates/jsonschema/src/properties.rs
@@ -21,9 +21,9 @@ pub(crate) enum CompiledPattern<R> {
     /// Exact match using `==` - for `^...$` patterns.
     Exact(Arc<str>),
     /// `^(a|b|c)$` — linear scan over a small sorted array of alternatives.
-    Alternation(Arc<[String]>, Arc<str>),
+    Alternation(Arc<[String]>),
     /// `^\S*$` — no ECMA-262 whitespace characters.
-    NoWhitespace(Arc<str>),
+    NoWhitespace,
     /// Full regex pattern.
     Regex(R),
 }
@@ -36,21 +36,10 @@ impl<R: crate::regex::RegexEngine> crate::regex::RegexEngine for CompiledPattern
         match self {
             CompiledPattern::Prefix(prefix) => Ok(text.starts_with(prefix.as_ref())),
             CompiledPattern::Exact(exact) => Ok(text == exact.as_ref()),
-            CompiledPattern::Alternation(alts, _) => Ok(alts.iter().any(|a| a.as_str() == text)),
-            CompiledPattern::NoWhitespace(_) => Ok(!text.chars().any(is_ecma_whitespace)),
+            CompiledPattern::Alternation(alts) => Ok(alts.iter().any(|a| a.as_str() == text)),
+            CompiledPattern::NoWhitespace => Ok(!text.chars().any(is_ecma_whitespace)),
             // Treat regex errors as non-match for compatibility
             CompiledPattern::Regex(re) => Ok(re.is_match(text).unwrap_or(false)),
-        }
-    }
-
-    fn pattern(&self) -> &str {
-        match self {
-            CompiledPattern::Prefix(prefix) => prefix.as_ref(),
-            CompiledPattern::Exact(exact) => exact.as_ref(),
-            CompiledPattern::Alternation(_, original) | CompiledPattern::NoWhitespace(original) => {
-                original.as_ref()
-            }
-            CompiledPattern::Regex(re) => re.pattern(),
         }
     }
 }
@@ -171,13 +160,10 @@ pub(crate) fn compile_fancy_regex_patterns<'a>(
         let compiled_pattern = match analyze_pattern(pattern) {
             Some(PatternOptimization::Prefix(prefix)) => CompiledPattern::Prefix(Arc::from(prefix)),
             Some(PatternOptimization::Exact(exact)) => CompiledPattern::Exact(Arc::from(exact)),
-            Some(PatternOptimization::Alternation(alts)) => CompiledPattern::Alternation(
-                Arc::from(alts.into_boxed_slice()),
-                Arc::from(pattern.as_str()),
-            ),
-            Some(PatternOptimization::NoWhitespace) => {
-                CompiledPattern::NoWhitespace(Arc::from(pattern.as_str()))
+            Some(PatternOptimization::Alternation(alts)) => {
+                CompiledPattern::Alternation(Arc::from(alts.into_boxed_slice()))
             }
+            Some(PatternOptimization::NoWhitespace) => CompiledPattern::NoWhitespace,
             None => {
                 let regex = ctx.get_or_compile_regex(pattern).map_err(|()| {
                     ValidationError::format(
@@ -211,13 +197,10 @@ pub(crate) fn compile_regex_patterns<'a>(
         let compiled_pattern = match analyze_pattern(pattern) {
             Some(PatternOptimization::Prefix(prefix)) => CompiledPattern::Prefix(Arc::from(prefix)),
             Some(PatternOptimization::Exact(exact)) => CompiledPattern::Exact(Arc::from(exact)),
-            Some(PatternOptimization::Alternation(alts)) => CompiledPattern::Alternation(
-                Arc::from(alts.into_boxed_slice()),
-                Arc::from(pattern.as_str()),
-            ),
-            Some(PatternOptimization::NoWhitespace) => {
-                CompiledPattern::NoWhitespace(Arc::from(pattern.as_str()))
+            Some(PatternOptimization::Alternation(alts)) => {
+                CompiledPattern::Alternation(Arc::from(alts.into_boxed_slice()))
             }
+            Some(PatternOptimization::NoWhitespace) => CompiledPattern::NoWhitespace,
             None => {
                 let regex = ctx.get_or_compile_standard_regex(pattern).map_err(|()| {
                     ValidationError::format(

--- a/crates/jsonschema/src/regex.rs
+++ b/crates/jsonschema/src/regex.rs
@@ -1,8 +1,6 @@
 pub(crate) trait RegexEngine: Sized + Send + Sync {
     type Error: RegexError;
     fn is_match(&self, text: &str) -> Result<bool, Self::Error>;
-
-    fn pattern(&self) -> &str;
 }
 
 /// Reason a regex match failed, distinguishing real engine errors from recovered panics.
@@ -47,10 +45,6 @@ impl RegexEngine for fancy_regex::Regex {
             Err(_) => Err(FancyRegexError::Panicked),
         }
     }
-
-    fn pattern(&self) -> &str {
-        self.as_str()
-    }
 }
 
 /// Marker error for `regex::Regex::is_match` panics. The underlying `is_match` is otherwise infallible.
@@ -73,10 +67,6 @@ impl RegexEngine for regex::Regex {
         }))
         .map_err(|_| RegexBackendPanic)
     }
-
-    fn pattern(&self) -> &str {
-        self.as_str()
-    }
 }
 
 /// Uninhabited error type for literal matchers — matching never fails.
@@ -93,21 +83,16 @@ impl RegexError for LiteralMatchError {
 pub(crate) enum LiteralMatcher {
     Prefix {
         literal: String,
-        original: String,
     },
     Exact {
         exact: String,
-        original: String,
     },
     /// `^(a|b|c)$` — linear scan over a small sorted array.
     Alternation {
         alternatives: Vec<String>,
-        original: String,
     },
     /// `^\S*$` — no ECMA-262 whitespace characters.
-    NoWhitespace {
-        original: String,
-    },
+    NoWhitespace,
 }
 
 impl RegexEngine for LiteralMatcher {
@@ -116,21 +101,12 @@ impl RegexEngine for LiteralMatcher {
     #[inline]
     fn is_match(&self, text: &str) -> Result<bool, Self::Error> {
         match self {
-            Self::Prefix { literal, .. } => Ok(text.starts_with(literal.as_str())),
-            Self::Exact { exact, .. } => Ok(text == exact.as_str()),
-            Self::Alternation { alternatives, .. } => {
+            Self::Prefix { literal } => Ok(text.starts_with(literal.as_str())),
+            Self::Exact { exact } => Ok(text == exact.as_str()),
+            Self::Alternation { alternatives } => {
                 Ok(alternatives.iter().any(|a| a.as_str() == text))
             }
-            Self::NoWhitespace { .. } => Ok(!text.chars().any(is_ecma_whitespace)),
-        }
-    }
-
-    fn pattern(&self) -> &str {
-        match self {
-            Self::Prefix { original, .. }
-            | Self::Exact { original, .. }
-            | Self::Alternation { original, .. }
-            | Self::NoWhitespace { original } => original.as_str(),
+            Self::NoWhitespace => Ok(!text.chars().any(is_ecma_whitespace)),
         }
     }
 }


### PR DESCRIPTION
Fixes #1149 