### PR TITLE
fix: Fused array shape checking the length bound when a custom keyword overrides minItems/maxItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- `type: array` with `items` and `minItems`/`maxItems` checking the built-in length bound even when a custom keyword overrides `minItems` or `maxItems`, so the bound was evaluated twice.
 - `#[jsonschema::validator]` generated code that named `serde_json` directly, so it needed the consumer crate to depend on `serde_json` too.
 - Canonicalization of `not` over an object with `properties`, `patternProperties` and `additionalProperties`, which applied `additionalProperties` to the keys listed in `properties`.
 

--- a/crates/jsonschema/src/keywords/items.rs
+++ b/crates/jsonschema/src/keywords/items.rs
@@ -1274,6 +1274,10 @@ pub(crate) fn array_shape_fusion<F: Json>(
     }
     for key in ["minItems", "maxItems"] {
         if let Some(value) = parent.get(key) {
+            // A custom keyword owns the bound; the fused validator must not check it too.
+            if ctx.get_keyword_factory(key).is_some() {
+                return false;
+            }
             if accepts_item_count(ctx, value).is_none() {
                 return false;
             }
@@ -1439,6 +1443,33 @@ mod tests {
     fn array_shape_invalid_length_keeps_error() {
         let schema = json!({"type": "array", "minItems": 1.5, "items": {"type": "number"}});
         assert!(crate::validator_for(&schema).is_err());
+    }
+
+    #[test]
+    fn array_shape_yields_to_custom_length_keyword() {
+        struct Accept;
+
+        impl<'i> crate::Keyword<'i> for Accept {
+            fn validate(&self, _: &'i Value) -> Result<(), crate::ValidationError<'i>> {
+                Ok(())
+            }
+
+            fn is_valid(&self, _: &'i Value) -> bool {
+                true
+            }
+        }
+
+        let schema = json!({"type": "array", "minItems": 3, "items": {"type": "number"}});
+        let validator = crate::options()
+            .with_keyword("minItems", |_, _, _| Ok(Box::new(Accept)))
+            .build(&schema)
+            .unwrap();
+
+        // The custom keyword owns `minItems`; the built-in bound must not also reject.
+        assert!(validator.is_valid(&json!([1])));
+        assert_eq!(validator.iter_errors(&json!([1])).count(), 0);
+        // `type` and `items` still apply.
+        assert!(!validator.is_valid(&json!([1, "x"])));
     }
 
     #[test]


### PR DESCRIPTION
Since 0.49, `type: "array"` + `items` + `minItems`/`maxItems` is fused into a
single `ArrayShapeValidator`. The built-in `minItems`/`maxItems` compilers know
about this and return `None` when the fusion applies, so the bound is checked
once.

The compiler dispatches to custom keyword factories before the built-in ones,
but `array_shape_fusion` never checks whether a custom factory is registered
for `minItems` or `maxItems`. When one is, the schema ends up with two
validators for the same bound: the fused built-in one and the custom one.

This shows up as duplicate errors for one violation, and it defeats the point
of overriding the keyword. For example, a custom `minItems` that keeps bounds
past `u64` exact still gets a second, saturated `u64::MAX` check from the fused
validator.

Fix: `array_shape_fusion` bails out when a custom factory is registered for
`minItems` or `maxItems`. `type` and `items` then compile through the regular
path, and the custom keyword is the only thing checking the bound.

Includes a regression test.